### PR TITLE
[FEAT] 스트릭 기록 일괄 업데이트(초기화) 구현

### DIFF
--- a/src/main/java/oncog/cogroom/domain/content/entity/ContentMember.java
+++ b/src/main/java/oncog/cogroom/domain/content/entity/ContentMember.java
@@ -30,7 +30,8 @@ public class ContentMember extends BaseTimeEntity {
     private Member member;
 
     @Column(precision = 5, scale = 2, nullable = false) // 전체 자릿수 5, 소수점 이하 2자리까지 표시
-    private BigDecimal progressRate;
+    @Builder.Default
+    private BigDecimal progressRate = BigDecimal.ZERO;
 
     @Column(nullable = false)
     private LocalDateTime expireAt; // NULL 이면 무기한

--- a/src/main/java/oncog/cogroom/domain/daily/entity/AssignedQuestion.java
+++ b/src/main/java/oncog/cogroom/domain/daily/entity/AssignedQuestion.java
@@ -29,6 +29,7 @@ public class AssignedQuestion {
     private Question question;
 
     @Column(nullable = false)
+    @Builder.Default
     private boolean isAnswered = false;
 
     @CreatedDate

--- a/src/main/java/oncog/cogroom/domain/member/entity/Member.java
+++ b/src/main/java/oncog/cogroom/domain/member/entity/Member.java
@@ -43,9 +43,11 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "role")
-    private MemberRole role; // USER, ADMIN, INSTRUCTOR
+    @Builder.Default
+    private MemberRole role = MemberRole.USER; // USER, ADMIN, INSTRUCTOR
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "status")
-    private MemberStatus status; // ACTIVE, SUSPENDED, WITHDRAWN
+    @Builder.Default
+    private MemberStatus status = MemberStatus.ACTIVE; // ACTIVE, SUSPENDED, WITHDRAWN
 }

--- a/src/main/java/oncog/cogroom/domain/notice/entity/Notice.java
+++ b/src/main/java/oncog/cogroom/domain/notice/entity/Notice.java
@@ -21,6 +21,7 @@ public class Notice extends BaseTimeEntity {
     private String ImageUrl;
 
     @Column(nullable = false)
+    @Builder.Default
     private Long viewCount = 0L;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/oncog/cogroom/domain/streak/entity/Streak.java
+++ b/src/main/java/oncog/cogroom/domain/streak/entity/Streak.java
@@ -3,6 +3,7 @@ package oncog.cogroom.domain.streak.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import oncog.cogroom.domain.member.entity.Member;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -24,6 +25,14 @@ public class Streak {
     private String shareUrl;
 
     @Column(nullable = false)
-    private Integer totalDays; // 누적 스트릭 일 수
+    @Builder.Default
+    private Integer totalDays = 0; // 누적 스트릭 일 수
 
+    public void updateTotalDays() {
+        this.totalDays += 1;
+    }
+
+    public void resetTotalDays() {
+        this.totalDays = 0;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/streak/repository/StreakLogRepository.java
+++ b/src/main/java/oncog/cogroom/domain/streak/repository/StreakLogRepository.java
@@ -1,0 +1,10 @@
+package oncog.cogroom.domain.streak.repository;
+
+import oncog.cogroom.domain.streak.entity.StreakLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface StreakLogRepository extends JpaRepository<StreakLog, Long> {
+    boolean existsByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/oncog/cogroom/domain/streak/repository/StreakRepository.java
+++ b/src/main/java/oncog/cogroom/domain/streak/repository/StreakRepository.java
@@ -1,0 +1,7 @@
+package oncog.cogroom.domain.streak.repository;
+
+import oncog.cogroom.domain.streak.entity.Streak;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StreakRepository extends JpaRepository<Streak, Long> {
+}

--- a/src/main/java/oncog/cogroom/domain/streak/scheduler/StreakSchduler.java
+++ b/src/main/java/oncog/cogroom/domain/streak/scheduler/StreakSchduler.java
@@ -1,0 +1,23 @@
+package oncog.cogroom.domain.streak.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.streak.service.StreakService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StreakSchduler {
+
+    private final StreakService streakService;
+
+    @Scheduled(cron = "0 0 0 * * *") // 자정마다
+//    @Scheduled(cron = "0 */2 * * * *") // 2분마다, 테스트용
+    public void updateStreakAtMidnight() {
+        log.info("스트릭 기록 초기화 시작");
+        streakService.updateAllMemberStreaks();
+        log.info("스트릭 기록 초기화 완료");
+    }
+}

--- a/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
+++ b/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
@@ -1,0 +1,47 @@
+package oncog.cogroom.domain.streak.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.streak.entity.Streak;
+import oncog.cogroom.domain.streak.repository.StreakLogRepository;
+import oncog.cogroom.domain.streak.repository.StreakRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class StreakService {
+
+    private final StreakRepository streakRepository;
+    private final StreakLogRepository streakLogRepository;
+
+    // 특정 멤버의 스트릭 기록 초기화
+    @Transactional
+    public void updateAllMemberStreaks() {
+        List<Streak> streaks = streakRepository.findAll();
+
+        LocalDateTime startOfYesterday = LocalDateTime.now().minusDays(1).toLocalDate().atStartOfDay();
+        LocalDateTime endOfYesterday = startOfYesterday.plusDays(1).minusNanos(1);
+
+        System.out.println("startOfYesterday: " + startOfYesterday);
+        System.out.println("endOfYesterday: " + endOfYesterday);
+
+        streaks.forEach(streak -> { // 추후 배치 적용 필요
+            Long memberId = streak.getMember().getId();
+
+           boolean hasYesterdayLog = streakLogRepository.existsByMemberIdAndCreatedAtBetween(
+                   memberId, startOfYesterday, endOfYesterday
+           );
+
+           // 해당 멤버가 전날에 작성한 log 정보가 없는 경우 누적 스트릭 일수를 0으로 초기화
+           if (!hasYesterdayLog && streak.getTotalDays() > 0) { // 기존에 0이 아닐 때만 0으로 초기화 (불필요한 업데이트 방지)
+               streak.resetTotalDays();
+           }
+        });
+    }
+}


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #15

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 자정마다 전 날의 스트릭 로그 기록이 없는 멤버들의 스트릭 연속 일수를 0으로 초기화합니다.

## 📝 참고사항
스트릭 연속 일수가 초기화가 아닌 +1이 되어야 하는 멤버들은 데일리 질문 답변 등록 시에 바로 업데이트 될 수 있도록 할 예정입니다.
