### PR TITLE
[FEAT] 사용자 정보 설정 API 구현 및 S3 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0' // swagger 1.x 버전은 스프링 2.x 버전과 맞음, 현재는 스프링 3.x를 쓰기에 2.x 사용이 맞음
 
+	//s3
+	implementation 'software.amazon.awssdk:s3:2.20.20' // AWS S3 SDK 의존성
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.member.dto.MemberRequestDTO;
 import oncog.cogroom.domain.member.service.MemberService;
 import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,14 +25,14 @@ public class memberController {
     public ResponseEntity<ApiResponse<MemberInfoDTO>> getMemberInfo() {
         MemberInfoDTO memberInfo = memberService.findMemberInfo();
 
-        return ResponseEntity.ok(ApiResponse.success(memberInfo));
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS,memberInfo));
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<Void>> updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request) {
         memberService.updateMemberInfo(request);
 
-        return ResponseEntity.ok(ApiResponse.success());
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
     }
 
 }

--- a/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
@@ -7,10 +7,7 @@ import oncog.cogroom.domain.member.service.MemberService;
 import oncog.cogroom.global.common.response.ApiResponse;
 import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static oncog.cogroom.domain.member.dto.MemberResponseDTO.MemberInfoDTO;
 
@@ -21,7 +18,7 @@ import static oncog.cogroom.domain.member.dto.MemberResponseDTO.MemberInfoDTO;
 public class memberController {
 
     private final MemberService memberService;
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<ApiResponse<MemberInfoDTO>> getMemberInfo() {
         MemberInfoDTO memberInfo = memberService.findMemberInfo();
 
@@ -29,7 +26,7 @@ public class memberController {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request) {
+    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(@RequestBody MemberRequestDTO.MemberInfoUpdateDTO request) {
         memberService.updateMemberInfo(request);
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));

--- a/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
@@ -1,5 +1,6 @@
 package oncog.cogroom.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.member.dto.MemberRequestDTO;
@@ -19,6 +20,7 @@ public class memberController {
 
     private final MemberService memberService;
     @GetMapping("")
+    @Operation(summary = "사용자 정보 조회 API", description = "사용자 정보 수정을 위해 사용자 정보를 조회합니다. \n 응답 코드에 따른 자세한 결과는 Notion 명세서를 참고 부탁드립니다.")
     public ResponseEntity<ApiResponse<MemberInfoDTO>> getMemberInfo() {
         MemberInfoDTO memberInfo = memberService.findMemberInfo();
 
@@ -26,10 +28,19 @@ public class memberController {
     }
 
     @PatchMapping("/me")
+    @Operation(summary = "사용자 정보 수정 API", description = "사용자 정보를 수정합니다. \n 응답 코드에 따른 자세한 결과는 Notion 명세서를 참고 부탁드립니다.")
     public ResponseEntity<ApiResponse<Void>> updateMemberInfo(@RequestBody MemberRequestDTO.MemberInfoUpdateDTO request) {
         memberService.updateMemberInfo(request);
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
+    }
+
+    @PostMapping("/me/nickname")
+    @Operation(summary = "닉네임 중복검사 API", description = "닉네임 중복 검사를 진행합니다. \n 응답 코드에 따른 자세한 결과는 Notion 명세서를 참고 부탁드립니다.")
+    public ResponseEntity<ApiResponse<Boolean>> existNickname(@RequestBody MemberRequestDTO.ExistNicknameDTO request) {
+        boolean isExist = memberService.existNickname(request);
+
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, isExist));
     }
 
 }

--- a/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/memberController.java
@@ -1,0 +1,37 @@
+package oncog.cogroom.domain.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.member.dto.MemberRequestDTO;
+import oncog.cogroom.domain.member.service.MemberService;
+import oncog.cogroom.global.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static oncog.cogroom.domain.member.dto.MemberResponseDTO.MemberInfoDTO;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/members")
+public class memberController {
+
+    private final MemberService memberService;
+    @GetMapping("/")
+    public ResponseEntity<ApiResponse<MemberInfoDTO>> getMemberInfo() {
+        MemberInfoDTO memberInfo = memberService.findMemberInfo();
+
+        return ResponseEntity.ok(ApiResponse.success(memberInfo));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request) {
+        memberService.updateMemberInfo(request);
+
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+}

--- a/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
@@ -16,4 +16,10 @@ public class MemberRequestDTO {
         private String description;
         private String phoneNumber;
     }
+
+    @Getter
+    @Builder
+    public static class ExistNicknameDTO {
+        private String nickname;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,19 @@
+package oncog.cogroom.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberRequestDTO {
+
+    @Builder
+    @Getter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class MemberInfoUpdateDTO {
+        private String email;
+        private String nickname;
+        private String imgUrl;
+        private String description;
+        private String phoneNumber;
+    }
+}

--- a/src/main/java/oncog/cogroom/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/oncog/cogroom/domain/member/dto/MemberResponseDTO.java
@@ -1,0 +1,17 @@
+package oncog.cogroom.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    public static class MemberInfoDTO {
+        private String email;
+        private String nickname;
+        private String imgUrl;
+        private String description;
+        private String phoneNumber;
+    }
+}

--- a/src/main/java/oncog/cogroom/domain/member/entity/Member.java
+++ b/src/main/java/oncog/cogroom/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package oncog.cogroom.domain.member.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import oncog.cogroom.domain.member.dto.MemberRequestDTO;
 import oncog.cogroom.global.common.entity.BaseTimeEntity;
 import oncog.cogroom.domain.member.enums.Provider;
 import oncog.cogroom.domain.member.enums.MemberRole;
@@ -50,4 +51,13 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false, name = "status")
     @Builder.Default
     private MemberStatus status = MemberStatus.ACTIVE; // ACTIVE, SUSPENDED, WITHDRAWN
+
+
+    public void updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request) {
+        this.email = request.getEmail();
+        this.description = request.getDescription();
+        this.phoneNumber = request.getPhoneNumber();
+        this.profileImageUrl = request.getImgUrl();
+        this.nickname = request.getNickname();
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/member/repository/MemberRepository.java
+++ b/src/main/java/oncog/cogroom/domain/member/repository/MemberRepository.java
@@ -10,9 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmail(String userEmail);
 
-    Optional<Member> findByProviderId(String providerId);
-
     Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
 
-    Boolean existsByProviderId(String ProviderId);
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -1,34 +1,46 @@
 package oncog.cogroom.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import oncog.cogroom.domain.member.dto.MemberRequestDTO;
 import oncog.cogroom.domain.member.entity.Member;
-import oncog.cogroom.domain.member.enums.MemberRole;
-import oncog.cogroom.domain.member.enums.MemberStatus;
 import oncog.cogroom.domain.member.repository.MemberRepository;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import oncog.cogroom.global.security.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
+
+import static oncog.cogroom.domain.member.dto.MemberResponseDTO.*;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
 
-    public boolean isExist(String providerId) {
-        return memberRepository.existsByProviderId(providerId);
+    public MemberInfoDTO findMemberInfo() {
+        Long memberId = jwtProvider.extractMemberId();
+
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("member not found"));
+
+        return MemberInfoDTO.builder()
+                .email(member.getEmail())
+                .description(member.getDescription())
+                .imgUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .phoneNumber(member.getPhoneNumber())
+                .build();
     }
 
-    public Member find(OAuth2User user) {
-        return memberRepository.findByProviderId(user.getAttribute("providerId"))
-                .orElseGet(() -> {
-                    return Member.builder()
-                            .email(user.getAttribute("email"))
-                            .nickname(user.getAttribute("nickname"))
-                            .role(MemberRole.USER)
-                            .provider(user.getAttribute("provider"))
-                            .providerId(user.getAttribute("providerId"))
-                            .status(MemberStatus.ACTIVE)
-                            .build();
-                });
+    public void updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request){
+        Long memberId = jwtProvider.extractMemberId();
+
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("member not found"));
+
+        member.updateMemberInfo(request);
     }
-}
+
+    public boolean isExist(String memberId) {
+        return memberRepository.existsById(Long.valueOf(memberId));
+    }
+
+
+    }

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
         return MemberInfoDTO.builder()
                 .email(member.getEmail())
                 .description(member.getDescription())
-                .imgUrl(member.getProfileImageUrl())
+                .imgUrl(member.getProfileImageUrl()) // preSignedUrl 방식 적용 필요
                 .nickname(member.getNickname())
                 .phoneNumber(member.getPhoneNumber())
                 .build();

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -37,7 +37,20 @@ public class MemberService {
 
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("member not found"));
 
+        if(!request.getPhoneNumber().matches("^01[016789]-\\d{3,4}-\\d{4}$")){
+            throw new IllegalArgumentException("전화번호 형식 오류");
+        }
+
         member.updateMemberInfo(request);
+    }
+
+    public boolean existNickname(MemberRequestDTO.ExistNicknameDTO request) {
+
+        if(memberRepository.existsByNickname(request.getNickname())){
+            throw new IllegalArgumentException("이미 존재하는 닉네임");
+        }
+
+        return false;
     }
 
     public boolean isExist(String memberId) {

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -6,11 +6,13 @@ import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.security.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static oncog.cogroom.domain.member.dto.MemberResponseDTO.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class MemberService {
 
     private final MemberRepository memberRepository;

--- a/src/main/java/oncog/cogroom/global/config/S3Config.java
+++ b/src/main/java/oncog/cogroom/global/config/S3Config.java
@@ -1,0 +1,46 @@
+package oncog.cogroom.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.credentials.access-key}")
+    private String s3AccessKey;
+
+    @Value("${aws.s3.credentials.secret-key}")
+    private String s3SecretKey;
+
+    @Value("${aws.s3.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                                s3AccessKey,
+                                s3SecretKey
+                        )
+                )).build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsCredentials credentials = AwsBasicCredentials.create(s3AccessKey,s3SecretKey);
+
+        return S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
+++ b/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     private final CustomUserDetailService userDetailService;
 
     @Bean
-    @Order(1)
+    @Order(2)
     public SecurityFilterChain filterChainPermitAll(HttpSecurity http) throws Exception {
         configureCommonSecuritySettings(http);
 
@@ -40,32 +40,32 @@ public class SecurityConfig {
         return http.build();
     }
 
-    // 추후 주석 해제 예정
-//    @Bean
-//    @Order(2)
-//    public SecurityFilterChain filterChainAuthorized(HttpSecurity http) throws Exception {
-//        configureCommonSecuritySettings(http);
-//
-//        http.securityMatchers(matchers -> matchers.requestMatchers(requestHasRoleUser()))
-//                .authorizeHttpRequests(auth -> auth
-//                        .anyRequest()
-//                        .hasAuthority(MemberRole.USER.name()));
-//
-//        http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider,userDetailService),
-//                UsernamePasswordAuthenticationFilter.class);
-//
-//        return http.build();
-//    }
-//
-//
-//    // 인증 및 인가가 필요한 엔드포인트에 적용되는 RequestMatcher
-//    private RequestMatcher[] requestHasRoleUser() {
-//        List<RequestMatcher> requestMatchers = List.of(
-//                antMatcher("/api/v1/daily/**")
-//        );
-//
-//        return requestMatchers.toArray(RequestMatcher[]::new);
-//    }
+//     추후 주석 해제 예정
+    @Bean
+    @Order(1)
+    public SecurityFilterChain filterChainAuthorized(HttpSecurity http) throws Exception {
+        configureCommonSecuritySettings(http);
+
+        http.securityMatchers(matchers -> matchers.requestMatchers(requestHasRoleUser()))
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest()
+                        .hasAuthority(MemberRole.USER.name()));
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider,userDetailService),
+                UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+
+    // 인증 및 인가가 필요한 엔드포인트에 적용되는 RequestMatcher
+    private RequestMatcher[] requestHasRoleUser() {
+        List<RequestMatcher> requestMatchers = List.of(
+                antMatcher("/api/v1/members/**")
+        );
+
+        return requestMatchers.toArray(RequestMatcher[]::new);
+    }
 
     // permitAll 권한을 가진 엔드포인트에 적용되는 RequestMatcher
     private RequestMatcher[] requestPermitAll() {

--- a/src/main/java/oncog/cogroom/global/s3/S3Service.java
+++ b/src/main/java/oncog/cogroom/global/s3/S3Service.java
@@ -1,0 +1,67 @@
+package oncog.cogroom.global.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    public String generatePreSignedUrl(String fileName, String contentType) {
+        PutObjectRequest uploadFile = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(uploadFile)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+
+        return presignedRequest.url().toString();
+    }
+
+    public String uploadFile(MultipartFile file, String directory) {
+        String fileName = directory + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+        try {
+            PutObjectRequest putRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileName)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(putRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+            return fileName;
+        } catch (IOException e) {
+            throw new RuntimeException("s3 파일 업로드 실패",e);
+        }
+    }
+
+
+}

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -6,6 +6,7 @@ import oncog.cogroom.global.s3.dto.S3RequestDTO;
 import oncog.cogroom.global.s3.service.S3Service;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,8 +17,8 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @GetMapping("/presigned-url/upload")
-    public ResponseEntity<ApiResponse<String>> getPreSignedUrl(S3RequestDTO.PreSignedUrlRequestDTO request) {
+    @GetMapping("/preSigned-url/upload")
+    public ResponseEntity<ApiResponse<String>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
         String preSignedUrl = s3Service.generatePreSignedUrl(request.getFileName(), request.getContentType()); // 추후 DTO로 대체
 
         return ResponseEntity.ok(ApiResponse.success(preSignedUrl));

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -2,6 +2,7 @@ package oncog.cogroom.global.s3.controller;
 
 import lombok.RequiredArgsConstructor;
 import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import oncog.cogroom.global.s3.dto.S3RequestDTO;
 import oncog.cogroom.global.s3.service.S3Service;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class S3Controller {
     public ResponseEntity<ApiResponse<List<String>>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
         List<String> preSignedUrls = s3Service.generatePreSignedUrl(request);
 
-        return ResponseEntity.ok(ApiResponse.success(preSignedUrls));
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS,preSignedUrls));
     }
 
 

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -2,6 +2,7 @@ package oncog.cogroom.global.s3.controller;
 
 import lombok.RequiredArgsConstructor;
 import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.s3.dto.S3RequestDTO;
 import oncog.cogroom.global.s3.service.S3Service;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,8 +17,8 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @GetMapping("/presigned-url/upload")
-    public ResponseEntity<ApiResponse<String>> getPreSignedUrl() {
-        String preSignedUrl = s3Service.generatePreSignedUrl(",", ","); // 추후 DTO로 대체
+    public ResponseEntity<ApiResponse<String>> getPreSignedUrl(S3RequestDTO.PreSignedUrlRequestDTO request) {
+        String preSignedUrl = s3Service.generatePreSignedUrl(request.getFileName(), request.getContentType()); // 추후 DTO로 대체
 
         return ResponseEntity.ok(ApiResponse.success(preSignedUrl));
     }

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/files")
@@ -18,10 +20,10 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @GetMapping("/preSigned-url/upload")
-    public ResponseEntity<ApiResponse<String>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
-        String preSignedUrl = s3Service.generatePreSignedUrl(request.getFileName(), request.getContentType()); // 추후 DTO로 대체
+    public ResponseEntity<ApiResponse<List<String>>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
+        List<String> preSignedUrls = s3Service.generatePreSignedUrl(request);
 
-        return ResponseEntity.ok(ApiResponse.success(preSignedUrl));
+        return ResponseEntity.ok(ApiResponse.success(preSignedUrls));
     }
 
 

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -1,0 +1,26 @@
+package oncog.cogroom.global.s3.controller;
+
+import lombok.RequiredArgsConstructor;
+import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.s3.service.S3Service;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/files")
+public class S3Controller {
+
+    private final S3Service s3Service;
+
+    @GetMapping("/presigned-url/upload")
+    public ResponseEntity<ApiResponse<String>> getPreSignedUrl() {
+        String preSignedUrl = s3Service.generatePreSignedUrl(",", ","); // 추후 DTO로 대체
+
+        return ResponseEntity.ok(ApiResponse.success(preSignedUrl));
+    }
+
+
+}

--- a/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
+++ b/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
@@ -3,12 +3,13 @@ package oncog.cogroom.global.s3.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Map;
+
 public class S3RequestDTO {
 
     @Builder
     @Getter
     public static class PreSignedUrlRequestDTO {
-        private String fileName;
-        private String contentType;
+        private Map<String, String> fileSet;
     }
 }

--- a/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
+++ b/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
@@ -1,0 +1,14 @@
+package oncog.cogroom.global.s3.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class S3RequestDTO {
+
+    @Builder
+    @Getter
+    public static class PreSignedUrlRequestDTO {
+        private String fileName;
+        private String contentType;
+    }
+}

--- a/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
+++ b/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
@@ -1,4 +1,4 @@
-package oncog.cogroom.global.s3;
+package oncog.cogroom.global.s3.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -14,7 +15,10 @@ import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignReques
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +31,10 @@ public class S3Service {
     @Value("${aws.s3.bucket}")
     private String bucket;
 
+    @Value("${aws.s3.cloud-front}")
+    private String cloudFrontUrl;
+
+    // 단일 파일 업로드
     public String generatePreSignedUrl(String fileName, String contentType) {
         PutObjectRequest uploadFile = PutObjectRequest.builder()
                 .bucket(bucket)
@@ -44,6 +52,28 @@ public class S3Service {
         return presignedRequest.url().toString();
     }
 
+    // 복수 파일 업로드
+    public List<String> generatePreSignedUrl(Map<String, String> fileSet) {
+
+        return fileSet.entrySet().stream().map(file -> {
+            // 업로드 파일 요청 생성
+            PutObjectRequest uploadFile = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(file.getKey())
+                    .contentType(file.getValue())
+                    .build();
+
+            // preSignedUrl 요청 생성
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(10))
+                    .putObjectRequest(uploadFile)
+                    .build();
+
+            return s3Presigner.presignPutObject(presignRequest).url().toString();
+        }).collect(Collectors.toList());
+    }
+
+    // 백엔드에서 직접 파일 업로드
     public String uploadFile(MultipartFile file, String directory) {
         String fileName = directory + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
@@ -61,6 +91,21 @@ public class S3Service {
         } catch (IOException e) {
             throw new RuntimeException("s3 파일 업로드 실패",e);
         }
+    }
+
+    // s3 파일 삭제
+    public void deleteFile(String fileUrl) {
+        String fileKey = extractKey(fileUrl);
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileKey)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+    public String extractKey(String fileUrl) {
+        return fileUrl.replace(cloudFrontUrl, "");
     }
 
 

--- a/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
+++ b/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
@@ -2,6 +2,7 @@ package oncog.cogroom.global.s3.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.global.s3.dto.S3RequestDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,9 +54,9 @@ public class S3Service {
     }
 
     // 복수 파일 업로드
-    public List<String> generatePreSignedUrl(Map<String, String> fileSet) {
+    public List<String> generatePreSignedUrl(S3RequestDTO.PreSignedUrlRequestDTO request) {
 
-        return fileSet.entrySet().stream().map(file -> {
+        return request.getFileSet().entrySet().stream().map(file -> {
             // 업로드 파일 요청 생성
             PutObjectRequest uploadFile = PutObjectRequest.builder()
                     .bucket(bucket)
@@ -93,16 +94,18 @@ public class S3Service {
         }
     }
 
-    // s3 파일 삭제
-    public void deleteFile(String fileUrl) {
-        String fileKey = extractKey(fileUrl);
+    // s3 파일 삭제 (추후 강의 기능 적용시 변경 사항 발생 가능)
+    public void deleteFile(List<String> fileUrls) {
+        fileUrls.forEach(fileUrl -> {
+            String fileKey = extractKey(fileUrl);
 
-        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
-                .bucket(bucket)
-                .key(fileKey)
-                .build();
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .build();
 
-        s3Client.deleteObject(deleteRequest);
+            s3Client.deleteObject(deleteRequest);
+        });
     }
     public String extractKey(String fileUrl) {
         return fileUrl.replace(cloudFrontUrl, "");

--- a/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
+++ b/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
@@ -42,14 +42,14 @@ public class S3Service {
                 .contentType(contentType)
                 .build();
 
-        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+        PutObjectPresignRequest preSignRequest = PutObjectPresignRequest.builder()
                 .signatureDuration(Duration.ofMinutes(10))
                 .putObjectRequest(uploadFile)
                 .build();
 
-        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+        PresignedPutObjectRequest preSignedRequest = s3Presigner.presignPutObject(preSignRequest);
 
-        return presignedRequest.url().toString();
+        return preSignedRequest.url().toString();
     }
 
     // 복수 파일 업로드
@@ -64,12 +64,12 @@ public class S3Service {
                     .build();
 
             // preSignedUrl 요청 생성
-            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+            PutObjectPresignRequest preSignRequest = PutObjectPresignRequest.builder()
                     .signatureDuration(Duration.ofMinutes(10))
                     .putObjectRequest(uploadFile)
                     .build();
 
-            return s3Presigner.presignPutObject(presignRequest).url().toString();
+            return s3Presigner.presignPutObject(preSignRequest).url().toString();
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.global.security.domain.CustomUserDetails;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -65,6 +66,16 @@ public class JwtProvider {
                 .build()
                 .parseSignedClaims(token)
                 .getPayload();
+    }
+
+    // Spring Security Context에서 memberId 추출
+    public Long extractMemberId() {
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
+
+        return userDetails.getMemberId();  // userId를 Long 타입으로 변환
     }
 
     private SecretKey generateSecretKey(){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ aws:
     bucket: ${S3_BUCKET}
     region:
       static: ${S3_REGION}
-#    cloud-front: ${S3_CLOUD_FRONT_URL}
+    cloud-front: ${CLOUD_FRONT_URL}
     credentials:
       access-key: ${S3_ACCESS_KEY}
       secret-key: ${S3_SECRET_KEY}


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #19 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 사용자 정보 수정 API 구현
- S3 PreSignedUrl 요청 API 구현
- S3 파일 삭제 API 구현
- S3 관련 설정 파일 생성
- response 변경에 의한 컨트롤러 코드 수정

## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->

## PreSignedUrl 발급
![image](https://github.com/user-attachments/assets/6e3b8a05-38d0-4b38-ab0f-25f70ec6e10d)

## 사용자 정보 조회
![image](https://github.com/user-attachments/assets/ad31d12d-2177-48c5-9e8f-eba3e1c96145)

## 사용자 정보 설정
![image](https://github.com/user-attachments/assets/3feb05c8-5660-4d87-8a7a-7afa1fb5af7f)

