### PR TITLE
[FEAT] 데일리 답변 등록 및 수정 API 구현

### DIFF
--- a/src/main/java/oncog/cogroom/domain/daily/controller/DailyController.java
+++ b/src/main/java/oncog/cogroom/domain/daily/controller/DailyController.java
@@ -1,21 +1,22 @@
 package oncog.cogroom.domain.daily.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.daily.controller.docs.DailyControllerDocs;
+import oncog.cogroom.domain.daily.dto.request.DailyAnswerRequestDTO;
 import oncog.cogroom.domain.daily.dto.response.DailyQuestionResponseDTO;
 import oncog.cogroom.domain.daily.service.DailyService;
 import oncog.cogroom.global.common.response.ApiResponse;
 import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/daily")
-public class DailyController {
+public class DailyController implements DailyControllerDocs {
 
     private final DailyService dailyService;
 
@@ -24,9 +25,15 @@ public class DailyController {
 
         DailyQuestionResponseDTO response = dailyService.getTodayDailyQuestion();
 
-        return ResponseEntity
-                .status(ApiSuccessCode.SUCCESS.getStatus())
-                .body(ApiResponse.of(ApiSuccessCode.SUCCESS, response));
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, response));
+    }
+
+    @PostMapping("/answers")
+    public ResponseEntity<ApiResponse<String>> createDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request) {
+
+        dailyService.createDailyAnswer(request);
+
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
     }
 
 

--- a/src/main/java/oncog/cogroom/domain/daily/controller/DailyController.java
+++ b/src/main/java/oncog/cogroom/domain/daily/controller/DailyController.java
@@ -36,5 +36,13 @@ public class DailyController implements DailyControllerDocs {
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
     }
 
+    @PatchMapping("/answers")
+    public ResponseEntity<ApiResponse<String>> updateDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request) {
+
+        dailyService.updateDailyAnswer(request);
+
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
+    }
+
 
 }

--- a/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
@@ -1,0 +1,31 @@
+package oncog.cogroom.domain.daily.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import oncog.cogroom.domain.daily.dto.request.DailyAnswerRequestDTO;
+import oncog.cogroom.domain.daily.dto.response.DailyQuestionResponseDTO;
+import oncog.cogroom.domain.daily.exception.DailyErrorCode;
+import oncog.cogroom.domain.member.exception.MemberErrorCode;
+import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.common.response.code.ApiErrorCode;
+import oncog.cogroom.global.exception.swagger.ApiErrorCodeExamples;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Daily", description = "데일리 관련 API")
+public interface DailyControllerDocs {
+
+    @Operation(summary = "데일리 질문 조회", description = "멤버가 할당받은 데일리 질문을 조회합니다.")
+    @ApiErrorCodeExamples(
+            value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
+            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "INTERNAL_SERVER_ERROR"})
+    ResponseEntity<ApiResponse<DailyQuestionResponseDTO>> getDailyQuestion();
+
+    @Operation(summary = "데일리 답변 등록", description = "데일리 질문에 대한 답변을 등록합니다.")
+    @ApiErrorCodeExamples(
+            value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
+            include = {"MEMBER_NOT_FOUND", "QUESTION_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND",
+                    "INVALID_QUESTION", "ALREADY_ANSWERED", "EMPTY_FILED", "INTERNAL_SERVER_ERROR"})
+    ResponseEntity<ApiResponse<String>> createDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request);
+}

--- a/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
@@ -25,7 +25,12 @@ public interface DailyControllerDocs {
     @Operation(summary = "데일리 답변 등록", description = "데일리 질문에 대한 답변을 등록합니다.")
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
-            include = {"MEMBER_NOT_FOUND", "QUESTION_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND",
-                    "INVALID_QUESTION", "ALREADY_ANSWERED", "EMPTY_FILED", "INTERNAL_SERVER_ERROR"})
+            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "ALREADY_ANSWERED", "EMPTY_FILED", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<String>> createDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request);
+
+    @Operation(summary = "데일리 답변 수정", description = "데일리 질문에 대한 답변을 수정합니다.")
+    @ApiErrorCodeExamples(
+            value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
+            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "ANSWER_NOT_FOUND", "EMPTY_FILED", "INTERNAL_SERVER_ERROR"})
+    public ResponseEntity<ApiResponse<String>> updateDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request);
 }

--- a/src/main/java/oncog/cogroom/domain/daily/dto/request/DailyAnswerRequestDTO.java
+++ b/src/main/java/oncog/cogroom/domain/daily/dto/request/DailyAnswerRequestDTO.java
@@ -1,15 +1,12 @@
 package oncog.cogroom.domain.daily.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class DailyAnswerRequestDTO {
-    private Long questionId;
-
     @NotBlank
     private String answer;
 }

--- a/src/main/java/oncog/cogroom/domain/daily/dto/request/DailyAnswerRequestDTO.java
+++ b/src/main/java/oncog/cogroom/domain/daily/dto/request/DailyAnswerRequestDTO.java
@@ -1,0 +1,15 @@
+package oncog.cogroom.domain.daily.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DailyAnswerRequestDTO {
+    private Long questionId;
+
+    @NotBlank
+    private String answer;
+}

--- a/src/main/java/oncog/cogroom/domain/daily/entity/Answer.java
+++ b/src/main/java/oncog/cogroom/domain/daily/entity/Answer.java
@@ -27,4 +27,8 @@ public class Answer extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String answer;
+
+    public void updateAnswer(String newAnswer) {
+        this.answer = newAnswer;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/daily/entity/AssignedQuestion.java
+++ b/src/main/java/oncog/cogroom/domain/daily/entity/AssignedQuestion.java
@@ -3,7 +3,6 @@ package oncog.cogroom.domain.daily.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import oncog.cogroom.domain.member.entity.Member;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -32,9 +31,11 @@ public class AssignedQuestion {
     @Builder.Default
     private boolean isAnswered = false;
 
-    @CreatedDate
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     @Column(nullable = false, updatable = false)
     private LocalDateTime assignedDate;
 
+    public void setIsAnswered() {
+        this.isAnswered = true;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/daily/entity/QuestionCategory.java
+++ b/src/main/java/oncog/cogroom/domain/daily/entity/QuestionCategory.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import oncog.cogroom.domain.member.entity.Member;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "QUESTION_CATEGORY")
 public class QuestionCategory {
 

--- a/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
@@ -10,9 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum DailyErrorCode implements BaseErrorCode {
 
     DAILY_QUESTION_NOT_FOUND("DAILY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 질문을 찾을 수 없습니다."),
-    QUESTION_NOT_FOUND("QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
-    INVALID_QUESTION("INVALID_QUESTION", HttpStatus.BAD_REQUEST, "오늘 할당된 데일리 질문이 아닙니다."),
-    ALREADY_ANSWERED("ALREADY_ANSWERED", HttpStatus.CONFLICT, "이미 답변이 존재합니다.");
+    ALREADY_ANSWERED("ALREADY_ANSWERED", HttpStatus.CONFLICT, "이미 답변이 존재합니다."),
+    ANSWER_NOT_FOUND("ANSWER_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 답변을 찾을 수 없습니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DailyErrorCode implements BaseErrorCode {
 
-    DAILY_QUESTION_NOT_FOUND("DAILY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 질문을 찾을 수 없습니다.");
+    DAILY_QUESTION_NOT_FOUND("DAILY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 질문을 찾을 수 없습니다."),
+    QUESTION_NOT_FOUND("QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "해당 질문을 찾을 수 없습니다."),
+    INVALID_QUESTION("INVALID_QUESTION", HttpStatus.BAD_REQUEST, "오늘 할당된 데일리 질문이 아닙니다."),
+    ALREADY_ANSWERED("ALREADY_ANSWERED", HttpStatus.CONFLICT, "이미 답변이 존재합니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/oncog/cogroom/domain/daily/respository/AnswerRepository.java
+++ b/src/main/java/oncog/cogroom/domain/daily/respository/AnswerRepository.java
@@ -1,6 +1,8 @@
 package oncog.cogroom.domain.daily.respository;
 
 import oncog.cogroom.domain.daily.entity.Answer;
+import oncog.cogroom.domain.daily.entity.Question;
+import oncog.cogroom.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -15,4 +17,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         AND a.createdAt BETWEEN :start AND :end
     """)
     Optional<String> findByMemberAndCreatedAtBetween(Long id, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByMemberAndQuestion(Member member, Question question);
 }

--- a/src/main/java/oncog/cogroom/domain/daily/respository/AnswerRepository.java
+++ b/src/main/java/oncog/cogroom/domain/daily/respository/AnswerRepository.java
@@ -4,19 +4,13 @@ import oncog.cogroom.domain.daily.entity.Answer;
 import oncog.cogroom.domain.daily.entity.Question;
 import oncog.cogroom.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
-    @Query("""
-        SELECT a.answer FROM Answer a
-        WHERE a.member.id = :id
-        AND a.createdAt BETWEEN :start AND :end
-    """)
-    Optional<String> findByMemberAndCreatedAtBetween(Long id, LocalDateTime start, LocalDateTime end);
+    Optional<Answer> findByMemberAndCreatedAtBetween(Member member, LocalDateTime start, LocalDateTime end);
 
     boolean existsByMemberAndQuestion(Member member, Question question);
 }

--- a/src/main/java/oncog/cogroom/domain/daily/respository/AssignedQuestionRepository.java
+++ b/src/main/java/oncog/cogroom/domain/daily/respository/AssignedQuestionRepository.java
@@ -3,7 +3,6 @@ package oncog.cogroom.domain.daily.respository;
 import oncog.cogroom.domain.daily.entity.AssignedQuestion;
 import oncog.cogroom.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -11,9 +10,5 @@ import java.util.Optional;
 public interface AssignedQuestionRepository extends JpaRepository<AssignedQuestion, Long> {
     boolean existsByMemberAndAssignedDateAfter(Member member, LocalDateTime assignedDateAfter);
 
-    @Query("""
-        SELECT aq FROM AssignedQuestion aq
-        WHERE aq.member.id = :id AND aq.assignedDate = :assignedDate
-    """)
-    Optional<AssignedQuestion> findByMemberAndAssignedDate(Long id, LocalDateTime assignedDate);
+    Optional<AssignedQuestion> findByMemberAndAssignedDate(Member member, LocalDateTime assignedDate);
 }

--- a/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
+++ b/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
@@ -2,16 +2,25 @@ package oncog.cogroom.domain.daily.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.daily.dto.request.DailyAnswerRequestDTO;
 import oncog.cogroom.domain.daily.dto.response.DailyQuestionResponseDTO;
+import oncog.cogroom.domain.daily.entity.Answer;
 import oncog.cogroom.domain.daily.entity.AssignedQuestion;
+import oncog.cogroom.domain.daily.entity.Question;
 import oncog.cogroom.domain.daily.exception.DailyErrorCode;
 import oncog.cogroom.domain.daily.exception.DailyException;
 import oncog.cogroom.domain.daily.respository.AnswerRepository;
 import oncog.cogroom.domain.daily.respository.AssignedQuestionRepository;
+import oncog.cogroom.domain.daily.respository.QuestionRepository;
+import oncog.cogroom.domain.member.entity.Member;
+import oncog.cogroom.domain.member.exception.MemberErrorCode;
+import oncog.cogroom.domain.member.exception.MemberException;
+import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.domain.streak.entity.Streak;
-import oncog.cogroom.domain.streak.repository.StreakRepository;
+import oncog.cogroom.domain.streak.service.StreakService;
 import oncog.cogroom.global.common.service.BaseService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,7 +32,9 @@ public class DailyService extends BaseService {
 
     private final AnswerRepository answerRepository;
     private final AssignedQuestionRepository assignedQuestionRepository;
-    private final StreakRepository streakRepository;
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final StreakService streakService;
 
     public DailyQuestionResponseDTO getTodayDailyQuestion() {
         Long memberId = getMemberId();
@@ -31,7 +42,7 @@ public class DailyService extends BaseService {
         LocalDateTime startOfToday = getStartOfToday();
         LocalDateTime endOfToday = getEndOfToday();
 
-        int streakDays = getStreakDays(memberId);
+        int streakDays = streakService.getStreakDays(memberId);
 
         AssignedQuestion question = getAssignedQuestion(memberId, startOfToday);
 
@@ -46,10 +57,20 @@ public class DailyService extends BaseService {
 
     }
 
-    private int getStreakDays(Long memberId) {
-        return streakRepository.findByMemberId(memberId)
-                .map(Streak::getTotalDays)
-                .orElse(0);
+    @Transactional
+    public void createDailyAnswer(DailyAnswerRequestDTO request) {
+        Long memberId = getMemberId();
+        Member member = findMember(memberId);
+        Question question = findQuestion(request.getQuestionId());
+
+        checkDuplicateAnswer(member, question); // 중복 답변 확인
+
+        checkIsAssignedQuestion(member, question);
+
+        saveAnswer(member, question, request.getAnswer());
+        updateAssignedQuestionStatus(member);
+
+        updateStreakInfo(member);
     }
 
     private AssignedQuestion getAssignedQuestion(Long memberId, LocalDateTime date) {
@@ -67,5 +88,50 @@ public class DailyService extends BaseService {
 
     private LocalDateTime getEndOfToday() {
         return getStartOfToday().plusDays(1).minusNanos(1);
+    }
+
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private Question findQuestion(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new DailyException(DailyErrorCode.QUESTION_NOT_FOUND));
+    }
+
+    private void saveAnswer(Member member, Question question, String content) {
+        Answer answer = Answer.builder()
+                .member(member)
+                .question(question)
+                .answer(content)
+                .build();
+        answerRepository.save(answer);
+    }
+
+    private void updateAssignedQuestionStatus(Member member) {
+        LocalDateTime startOfToday = getStartOfToday();
+        AssignedQuestion assignedQuestion = getAssignedQuestion(member.getId(), startOfToday);
+        assignedQuestion.setIsAnswered();
+    }
+
+    private void checkDuplicateAnswer(Member member, Question question) {
+        if (answerRepository.existsByMemberAndQuestion(member, question)) {
+            throw new DailyException(DailyErrorCode.ALREADY_ANSWERED);
+        }
+    }
+
+    private void checkIsAssignedQuestion(Member member, Question question) {
+        LocalDateTime startOfToday = getStartOfToday();
+        AssignedQuestion assignedQuestion = getAssignedQuestion(member.getId(), startOfToday);
+        if (!assignedQuestion.getQuestion().getId().equals(question.getId())) {
+            throw new DailyException(DailyErrorCode.INVALID_QUESTION);
+        }
+    }
+
+    private void updateStreakInfo(Member member) {
+        Streak streak = streakService.getOrCreateStreak(member);
+        streak.updateTotalDays(); // 스트릭 날짜 + 1
+        streakService.createStreakLog(member, streak); // streak 로그 생성
     }
 }

--- a/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
+++ b/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
@@ -12,9 +12,6 @@ import oncog.cogroom.domain.daily.exception.DailyException;
 import oncog.cogroom.domain.daily.respository.AnswerRepository;
 import oncog.cogroom.domain.daily.respository.AssignedQuestionRepository;
 import oncog.cogroom.domain.member.entity.Member;
-import oncog.cogroom.domain.member.exception.MemberErrorCode;
-import oncog.cogroom.domain.member.exception.MemberException;
-import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.domain.streak.entity.Streak;
 import oncog.cogroom.domain.streak.service.StreakService;
 import oncog.cogroom.global.common.service.BaseService;
@@ -31,10 +28,7 @@ public class DailyService extends BaseService {
 
     private final AnswerRepository answerRepository;
     private final AssignedQuestionRepository assignedQuestionRepository;
-    private final MemberRepository memberRepository;
     private final StreakService streakService;
-
-
 
     public DailyQuestionResponseDTO getTodayDailyQuestion() {
         Member member = getMember();
@@ -97,11 +91,6 @@ public class DailyService extends BaseService {
 
     private LocalDateTime getEndOfToday() {
         return getStartOfToday().plusDays(1).minusNanos(1);
-    }
-
-    private Member getMember() {
-        return memberRepository.findById(getMemberId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
     private void saveAnswer(Member member, Question question, String content) {

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -7,7 +7,6 @@ import oncog.cogroom.domain.member.exception.MemberErrorCode;
 import oncog.cogroom.domain.member.exception.MemberException;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.common.service.BaseService;
-import oncog.cogroom.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,9 +20,7 @@ public class MemberService extends BaseService {
     private final MemberRepository memberRepository;
 
     public MemberInfoDTO findMemberInfo() {
-        Long memberId = getMemberId();
-
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member = getMember();
 
         return MemberInfoDTO.builder()
                 .email(member.getEmail())
@@ -35,9 +32,7 @@ public class MemberService extends BaseService {
     }
 
     public void updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request){
-        Long memberId = getMemberId();
-
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member = getMember();
 
         member.updateMemberInfo(request);
     }

--- a/src/main/java/oncog/cogroom/domain/streak/docs/StreakControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/streak/docs/StreakControllerDocs.java
@@ -1,17 +1,20 @@
 package oncog.cogroom.domain.streak.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import oncog.cogroom.domain.member.exception.MemberErrorCode;
 import oncog.cogroom.domain.streak.dto.response.StreakCalenderResponseDTO;
 import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.common.response.code.ApiErrorCode;
+import oncog.cogroom.global.exception.swagger.ApiErrorCodeExamples;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Streak", description = "스트릭 관련 API")
 public interface StreakControllerDocs {
 
     @Operation(summary = "물방울(스트릭) 기록 조회", description = "물방울 기록을 리스트로 반환합니다.")
-//    @ApiResponses(value = {
-//    })
+    @ApiErrorCodeExamples(
+            value = {MemberErrorCode.class, ApiErrorCode.class},
+            include = {"MEMBER_NOT_FOUND", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<StreakCalenderResponseDTO>> getStreakCalender();
 }

--- a/src/main/java/oncog/cogroom/domain/streak/entity/StreakLog.java
+++ b/src/main/java/oncog/cogroom/domain/streak/entity/StreakLog.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import oncog.cogroom.domain.member.entity.Member;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "STREAK_LOG")
 public class StreakLog {
 

--- a/src/main/java/oncog/cogroom/domain/streak/repository/StreakLogRepository.java
+++ b/src/main/java/oncog/cogroom/domain/streak/repository/StreakLogRepository.java
@@ -1,5 +1,6 @@
 package oncog.cogroom.domain.streak.repository;
 
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.streak.entity.StreakLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StreakLogRepository extends JpaRepository<StreakLog, Long> {
-    boolean existsByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+    boolean existsByMemberAndCreatedAtBetween(Member member, LocalDateTime start, LocalDateTime end);
 
-    List<StreakLog> findAllByMemberIdAndCreatedAtBetween(Long memberId, LocalDateTime start, LocalDateTime end);
+    List<StreakLog> findAllByMemberAndCreatedAtBetween(Member member, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/oncog/cogroom/domain/streak/repository/StreakRepository.java
+++ b/src/main/java/oncog/cogroom/domain/streak/repository/StreakRepository.java
@@ -1,10 +1,11 @@
 package oncog.cogroom.domain.streak.repository;
 
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.streak.entity.Streak;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface StreakRepository extends JpaRepository<Streak, Long> {
-    Optional<Streak> findByMemberId(Long memberId);
+    Optional<Streak> findByMember(Member member);
 }

--- a/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
+++ b/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
@@ -37,9 +37,9 @@ public class StreakService extends BaseService {
         List<Streak> streaks = streakRepository.findAll();
 
         streaks.forEach(streak -> { // 추후 배치 적용 필요
-            Long memberId = streak.getMember().getId();
+            Member member = streak.getMember();
 
-           boolean hasYesterdayLog = hasLogForYesterday(memberId, startOfYesterday, endOfYesterday);
+           boolean hasYesterdayLog = hasLogForYesterday(member, startOfYesterday, endOfYesterday);
 
            // 해당 멤버가 전날에 작성한 log 정보가 없는 경우 누적 스트릭 일수를 0으로 초기화
            if (!hasYesterdayLog && streak.getTotalDays() > 0) { // 기존에 0이 아닐 때만 0으로 초기화 (불필요한 업데이트 방지)
@@ -49,13 +49,13 @@ public class StreakService extends BaseService {
     }
 
     public StreakCalenderResponseDTO getStreakDates() {
-        Long memberId = getMemberId();
+        Member member = getMember();
 
         LocalDateTime startOfMonth = getStartOfCalenderMonth();
         LocalDateTime endOfMonth = getEndOfMonth();
 
         List<String> streakDates = streakLogRepository
-                .findAllByMemberIdAndCreatedAtBetween(memberId, startOfMonth, endOfMonth).stream()
+                .findAllByMemberAndCreatedAtBetween(member, startOfMonth, endOfMonth).stream()
                 .map(log -> log.getCreatedAt().toLocalDate().format(formatter))
                 .distinct()
                 .sorted()
@@ -66,8 +66,8 @@ public class StreakService extends BaseService {
                 .build();
     }
 
-    private boolean hasLogForYesterday(Long memberId, LocalDateTime start, LocalDateTime end) {
-        return streakLogRepository.existsByMemberIdAndCreatedAtBetween(memberId, start, end);
+    private boolean hasLogForYesterday(Member member, LocalDateTime start, LocalDateTime end) {
+        return streakLogRepository.existsByMemberAndCreatedAtBetween(member, start, end);
     }
 
     private LocalDateTime getStartOfYesterday() {

--- a/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
+++ b/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
@@ -2,7 +2,9 @@ package oncog.cogroom.domain.streak.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.streak.entity.Streak;
+import oncog.cogroom.domain.streak.entity.StreakLog;
 import oncog.cogroom.domain.streak.repository.StreakLogRepository;
 import oncog.cogroom.domain.streak.repository.StreakRepository;
 import oncog.cogroom.domain.streak.dto.response.StreakCalenderResponseDTO;
@@ -26,8 +28,6 @@ public class StreakService extends BaseService {
     private final StreakLogRepository streakLogRepository;
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
-
-     // 특정 멤버들의 전날 기록이 없으면 스트릭 일수를 0으로 초기화
     @Transactional
     public void updateAllMemberStreaks() {
 
@@ -48,7 +48,6 @@ public class StreakService extends BaseService {
         });
     }
 
-    // 스트릭 날짜 리스트 조회
     public StreakCalenderResponseDTO getStreakDates() {
         Long memberId = getMemberId();
 
@@ -95,4 +94,22 @@ public class StreakService extends BaseService {
     private LocalDateTime getEndOfMonth() {
         return LocalDate.now().withDayOfMonth(LocalDate.now().lengthOfMonth()).atTime(23, 59, 59);
     }
+
+    public Streak getOrCreateStreak(Member member) {
+        return streakRepository.findByMemberId(member.getId())
+                .orElseGet(() -> streakRepository.save(
+                        Streak.builder().member(member).build()
+                ));
+    }
+
+    public void createStreakLog(Member member, Streak streak) {
+        streakLogRepository.save(StreakLog.builder().member(member).streak(streak).build());
+    }
+
+    public int getStreakDays(Long memberId) {
+        return streakRepository.findByMemberId(memberId)
+                .map(Streak::getTotalDays)
+                .orElse(0);
+    }
+
 }

--- a/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
+++ b/src/main/java/oncog/cogroom/domain/streak/service/StreakService.java
@@ -96,7 +96,7 @@ public class StreakService extends BaseService {
     }
 
     public Streak getOrCreateStreak(Member member) {
-        return streakRepository.findByMemberId(member.getId())
+        return streakRepository.findByMember(member)
                 .orElseGet(() -> streakRepository.save(
                         Streak.builder().member(member).build()
                 ));
@@ -106,8 +106,8 @@ public class StreakService extends BaseService {
         streakLogRepository.save(StreakLog.builder().member(member).streak(streak).build());
     }
 
-    public int getStreakDays(Long memberId) {
-        return streakRepository.findByMemberId(memberId)
+    public int getStreakDays(Member member) {
+        return streakRepository.findByMember(member)
                 .map(Streak::getTotalDays)
                 .orElse(0);
     }

--- a/src/main/java/oncog/cogroom/global/common/service/BaseService.java
+++ b/src/main/java/oncog/cogroom/global/common/service/BaseService.java
@@ -1,7 +1,9 @@
 package oncog.cogroom.global.common.service;
 
-import oncog.cogroom.domain.auth.exception.AuthException;
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.exception.MemberErrorCode;
+import oncog.cogroom.domain.member.exception.MemberException;
+import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.security.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -10,8 +12,11 @@ public abstract class BaseService {
     @Autowired
     protected JwtProvider jwtProvider;
 
-    protected Long getMemberId() {
-        return jwtProvider.extractMemberId()
-                .orElseThrow(() -> new AuthException(MemberErrorCode.MEMBER_NOT_FOUND));
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    protected Member getMember() {
+        return memberRepository.findById(jwtProvider.extractMemberId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
-import java.util.Optional;
 
 @Component
 @Slf4j
@@ -71,24 +70,13 @@ public class JwtProvider {
                 .getPayload();
     }
 
-    public Optional<Long> extractMemberId() {
-        try {
-            var authentication = SecurityContextHolder.getContext().getAuthentication();
-            if (authentication == null || !authentication.isAuthenticated()) {
-                return Optional.empty();
-            }
+    public Long extractMemberId() {
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getPrincipal();
 
-            Object principal = authentication.getPrincipal();
-            if (principal instanceof CustomUserDetails userDetails) {
-                return Optional.of(userDetails.getMemberId());
-            }
-
-            return Optional.empty();
-
-        } catch (Exception e) {
-            log.error("extractMemberId 실패: {}", e.getMessage());
-            return Optional.empty();
-        }
+        return userDetails.getMemberId();
     }
 
     private SecretKey generateSecretKey(){

--- a/src/main/java/oncog/cogroom/global/security/service/CustomUserDetailService.java
+++ b/src/main/java/oncog/cogroom/global/security/service/CustomUserDetailService.java
@@ -3,7 +3,8 @@ package oncog.cogroom.global.security.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.member.entity.Member;
-import oncog.cogroom.domain.member.enums.Provider;
+import oncog.cogroom.domain.member.exception.MemberErrorCode;
+import oncog.cogroom.domain.member.exception.MemberException;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.security.domain.CustomUserDetails;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -21,7 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         Member member = memberRepository.findById(Long.valueOf(userId))
-                .orElseThrow(() -> new UsernameNotFoundException("사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         log.info("사용자 조회 완료");
 


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #37

## 📌 변경 사항
- streak, daily 스웨거 문서화
- 데일리 답변 등록 API 추가
- 데일리 답변 수정 API 추가
- 답변, 수정 dto에서 questionId 삭제
- BaseService 메서드 memberId -> member 객체 반환으로 수정
- jwt provider.extractId 메서드 optional -> long으로 수정

## 📝 참고사항
- BaseService getMember 메서드는 findById가 optional 반환 형태로 에러처리 필수이기 때문에 에러처리 해두었습니다.

<img width="1073" alt="image" src="https://github.com/user-attachments/assets/ba0691cd-3b09-4b92-b20c-86ac07d07a2e" />
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/5fa536ed-ec7c-4b38-adc1-04f9d0c7d92f" />
