### PR TITLE
[REFACTOR] 이메일 인증 상태 검사 API 추가 및 에러 코드 리팩토링

### DIFF
--- a/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
@@ -36,12 +36,13 @@ public class AuthController implements AuthControllerDocs {
     private final DailyQuestionAssignService dailyQuestionAssignService;
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<LoginResponseDTO>> socialLogin(@RequestBody @Valid LoginRequestDTO request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> login(@RequestBody @Valid LoginRequestDTO request, HttpServletResponse response) {
         LoginResponseDTO result = router.login(request);
 
         // Token 쿠키로 셋팅
         cookieUtil.addTokenForCookie(response, result.getTokens());
 
+        // response body 토큰 제거
         LoginResponseDTO responseExcludedToken = result.excludeTokens();
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, responseExcludedToken));
@@ -50,15 +51,19 @@ public class AuthController implements AuthControllerDocs {
 
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<SignupResponseDTO>> socialSignup(@RequestBody @Valid SignupRequestDTO request, HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<SignupResponseDTO>> signup(@RequestBody @Valid SignupRequestDTO request, HttpServletResponse response) {
         SignupResponseDTO result = router.signup(request);
 
         // Token 쿠키로 셋팅
         cookieUtil.addTokenForCookie(response, result.getTokens());
 
+        // response body 토큰 제거
         SignupResponseDTO responseExcludedToken = result.excludeTokens();
 
+
+        // 가입 후 질문 할당
         dailyQuestionAssignService.assignDailyQuestionAtSignup(request.getProvider(), request.getProviderId());
+
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, responseExcludedToken));
 

--- a/src/main/java/oncog/cogroom/domain/auth/docs/AuthControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/auth/docs/AuthControllerDocs.java
@@ -25,18 +25,18 @@ public interface AuthControllerDocs {
             value = AuthErrorCode.class,
             include = {"KAKAO_AUTH_FAILED", "KAKAO_INVALID_AUTHORIZATION_CODE"})
     @Operation(summary = "소셜/로컬 통합 로그인", description = "소셜/로컬 통합 로그인 로직을 처리합니다.")
-    public ResponseEntity<ApiResponse<AuthResponseDTO.LoginResponseDTO>> socialLogin(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO request, HttpServletResponse response);
+    public ResponseEntity<ApiResponse<AuthResponseDTO.LoginResponseDTO>> login(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, ApiErrorCode.class},
-            include = {"EMPTY_FILED", "INVALID_EMAIL_FOTMAT"})
+            include = {"EMPTY_FILED", "INVALID_EMAIL_FORMAT"})
     @Operation(summary = "소셜/로컬 통합 회원가입", description = "소셜/로컬 통합 회원가입 로직을 처리합니다. ")
-    public ResponseEntity<ApiResponse<AuthResponseDTO.SignupResponseDTO>> socialSignup(@RequestBody @Valid AuthRequestDTO.SignupRequestDTO request, HttpServletResponse response);
+    public ResponseEntity<ApiResponse<AuthResponseDTO.SignupResponseDTO>> signup(@RequestBody @Valid AuthRequestDTO.SignupRequestDTO request, HttpServletResponse response);
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, ApiErrorCode.class},
-            include = {"EMPTY_FILED", "INVALID_EMAIL_FOTMAT", "ALREADY_EXIST_EMAIL"})
+            include = {"EMPTY_FILED", "INVALID_EMAIL_FORMAT", "ALREADY_EXIST_EMAIL"})
     @Operation(summary = "인증 이메일 전송", description = "인증용 링크가 포함된 이메일을 전송합니다. ")
     public ResponseEntity<ApiResponse<String>> sendEmail(@RequestBody @Valid AuthRequestDTO.EmailRequestDTO request) throws MessagingException, IOException;
 

--- a/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements BaseErrorCode {
 
     // 유효성 검사
-    INVALID_EMAIL_FORMAT("INVALID_EMAIL_FOTMAT", HttpStatus.BAD_REQUEST, "이메일 형식이 잘못되었습니다."),
+    INVALID_EMAIL_FORMAT("INVALID_EMAIL_FORMAT", HttpStatus.BAD_REQUEST, "이메일 형식이 잘못되었습니다."),
     INVALID_PHONE_NUMBER_PATTERN("INVALID_PATTERN", HttpStatus.BAD_REQUEST, "형식이 올바르지 않습니다."),
     INVALID_PASSWORD_FORMAT("INVALID_PASSWORD_FORMAT", HttpStatus.BAD_REQUEST, "비밀번호 형식이 잘못되었습니다."),
 
@@ -23,8 +23,9 @@ public enum AuthErrorCode implements BaseErrorCode {
     ALREADY_BLACK_LIST("ALREADY_BLACK_LIST", HttpStatus.UNAUTHORIZED, "이미 블랙리스트에 포함된 토큰입니다."),
     EXPIRED_TOKEN("EXPIRED_TOKEN", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
 
-    // 이메일 전송
+    // 이메일
     ALREADY_EXIST_EMAIL("ALREADY_EXIST_EMAIL", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    NOT_VERIFIED_EMAIL("NOT_VERIFIED_EMAIL", HttpStatus.BAD_REQUEST, "인증된 이메일이 아닙니다."),
     EXPIRED_LINK("EXPIRED_LINK", HttpStatus.BAD_REQUEST, "인증 링크 시간이 만료되었습니다."),
 
 

--- a/src/main/java/oncog/cogroom/domain/auth/repository/EmailRepository.java
+++ b/src/main/java/oncog/cogroom/domain/auth/repository/EmailRepository.java
@@ -11,4 +11,6 @@ public interface EmailRepository extends JpaRepository<EmailVerification, Long> 
     Optional<EmailVerification> findByEmail(String email);
 
     Boolean existsByEmailAndVerifyStatus(String email, boolean status);
+
+
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
@@ -44,7 +44,7 @@ public class EmailService {
         MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
 
         helper.setTo(toEmail); // 목적지
-        helper.setSubject("Oncognier auth email"); // 타이틀
+        helper.setSubject("[코그룸/회원가입] 인증 링크"); // 타이틀
         helper.setText(generateVerificationLink(toEmail));
         helper.setFrom(fromEmail); // 발신 이메일
         mailSender.send(message);
@@ -74,13 +74,20 @@ public class EmailService {
 
     // 이메일 중복 검사
     public void existEmail(String toEmail) {
-        if(memberRepository.existsByEmail(toEmail)) throw new AuthException(AuthErrorCode.ALREADY_EXIST_EMAIL);
+        if(Boolean.TRUE.equals(memberRepository.existsByEmail(toEmail))) throw new AuthException(AuthErrorCode.ALREADY_EXIST_EMAIL);
     }
 
     // 이메일의 인증 상태 반환
     public boolean verifiedEmail(AuthRequestDTO.EmailRequestDTO request) {
         String toEmail = request.getEmail();
         return emailRepository.existsByEmailAndVerifyStatus(toEmail,true);
+    }
+
+    // 이메일 인증 유무 검사
+    public void isVerified(String email) {
+        Boolean isVerified = emailRepository.existsByEmailAndVerifyStatus(email, true);
+
+        if(Boolean.FALSE.equals(isVerified)) throw new AuthException(AuthErrorCode.NOT_VERIFIED_EMAIL);
     }
 
     // 이메일 인증 (boolean 형으로 변경 예정)

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
@@ -4,6 +4,7 @@ package oncog.cogroom.domain.auth.service.social;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.auth.service.AuthService;
+import oncog.cogroom.domain.auth.service.EmailService;
 import oncog.cogroom.domain.auth.userInfo.SocialUserInfo;
 import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.enums.MemberRole;
@@ -19,9 +20,10 @@ import static oncog.cogroom.domain.auth.dto.response.AuthResponseDTO.*;
 
 @RequiredArgsConstructor
 @Slf4j
-public abstract class AbstractSocialAuthService implements AuthService {
+public abstract class AbstractAuthService implements AuthService {
 
     private final MemberRepository memberRepository;
+    private final EmailService emailService;
     private final TokenUtil tokenUtil;
 
     // 소셜 로그인 공통 로직
@@ -52,6 +54,9 @@ public abstract class AbstractSocialAuthService implements AuthService {
 
     // 소셜 로그인의 경우 회원가입 클릭 -> 로그인 처리가 ui적으로 깔끔하기에 토큰 발급
     public final SignupResponseDTO signup(SignupRequestDTO request) {
+        // 이메일 인증 유무 검사
+        emailService.isVerified(request.getEmail());
+
         Member savedMember = memberRepository.save(Member.builder()
                 .email(request.getEmail())
                 .nickname(request.getNickname())

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
@@ -3,6 +3,7 @@ package oncog.cogroom.domain.auth.service.social;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.auth.dto.response.SocialTokenResponseDTO;
 import oncog.cogroom.domain.auth.exception.AuthErrorCode;
+import oncog.cogroom.domain.auth.service.EmailService;
 import oncog.cogroom.domain.auth.userInfo.KakaoUserInfo;
 import oncog.cogroom.domain.auth.userInfo.SocialUserInfo;
 import oncog.cogroom.domain.member.enums.Provider;
@@ -22,14 +23,14 @@ import static oncog.cogroom.domain.auth.dto.response.SocialUserInfoDTO.KakaoUser
 
 @Service
 @Slf4j
-public class KakaoAuthService extends AbstractSocialAuthService {
+public class KakaoAuthService extends AbstractAuthService {
     @Value("${oauth.kakao.client-id}")
     private String clientId;
 
     private final RestTemplate restTemplate;
 
-    public KakaoAuthService(MemberRepository memberRepository, TokenUtil tokenUtil, RestTemplate restTemplate) {
-        super( memberRepository,tokenUtil);
+    public KakaoAuthService(MemberRepository memberRepository, TokenUtil tokenUtil, EmailService emailService, RestTemplate restTemplate) {
+        super( memberRepository, emailService ,tokenUtil);
         this.restTemplate = restTemplate;
     }
 

--- a/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/oncog/cogroom/domain/member/dto/MemberRequestDTO.java
@@ -21,10 +21,9 @@ public class MemberRequestDTO {
 
         private String imageUrl;
 
-        @NotBlank
         private String description;
 
-        @NotBlank
+        @Pattern(regexp = "^01[0-9]-\\d{3,4}-\\d{4}$\n")
         private String phoneNumber;
 
         @Pattern(regexp = "^(?=.*[A-Z])(?=.*[@$!%*?&]).{8,16}$")

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package oncog.cogroom.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import oncog.cogroom.domain.auth.service.EmailService;
 import oncog.cogroom.domain.member.dto.MemberRequestDTO;
 import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.exception.MemberErrorCode;
@@ -23,6 +24,7 @@ public class MemberService extends BaseService {
 
     private final MemberRepository memberRepository;
     private final StreakService streakService;
+    private final EmailService emailService;
 
     public MemberInfoDTO findMemberInfo() {
         Member member = getMember();
@@ -64,6 +66,8 @@ public class MemberService extends BaseService {
 
     public void updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request){
         Member member = getMember();
+
+        emailService.isVerified(request.getEmail());
 
         member.updateMemberInfo(request);
     }

--- a/src/main/java/oncog/cogroom/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/oncog/cogroom/global/exception/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 @Slf4j
 @RestControllerAdvice
+
 public class GlobalExceptionHandler {
 
     // 커스텀 exception
@@ -65,12 +66,15 @@ public class GlobalExceptionHandler {
 
         if ("Pattern".equals(code)) {
             switch (field) {
-                case "password":
-                    return AuthErrorCode.INVALID_PASSWORD_FORMAT;
-                case "phoneNumber":
+                case "password" -> {
+                    return  AuthErrorCode.INVALID_PASSWORD_FORMAT;
+                }
+                case "phoneNumber" -> {
                     return AuthErrorCode.INVALID_PHONE_NUMBER_PATTERN;
-                default:
+                }
+                default -> {
                     return ApiErrorCode.INVALID_PATTERN;
+                }
             }
         }
 

--- a/src/main/java/oncog/cogroom/global/security/controller/LoadBalancerController.java
+++ b/src/main/java/oncog/cogroom/global/security/controller/LoadBalancerController.java
@@ -1,4 +1,4 @@
-package oncog.cogroom.global.s3.controller;
+package oncog.cogroom.global.security.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #53 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- GlobalErrorHandler 수정
- 이메일 인증 상태 검사 api 추가
- 이메일 인증 상태 검사 에러 코드 추가
- 유효성 검사 에러코드 오타 수정
- 전화번호 형식 검사 추가
- GlobalErrorHandler 내부 switch 조건문에서 지속적으로 default 케이스만 반환하는 에러 수정
  -> return switch 문법이 람다나 제네릭과 함꼐 사용될 때 제대로 작동하지 않는 버그가 원인

## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
## 이메일 인증 상태 검사
![image](https://github.com/user-attachments/assets/c8a68120-05e7-4bfb-a39f-ed6c8f53b1c0)
