### PR TITLE
[REFACTOR] 에러 코드 네이밍 통일

### DIFF
--- a/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
@@ -26,20 +26,21 @@ public interface AuthControllerDocs {
 
     @ApiErrorCodeExample(
             value = AuthErrorCode.class,
-            include = {"KAKAO_AUTH_FAILED", "KAKAO_INVALID_AUTHORIZATION_CODE"})
+            include = {"KAKAO_REQUEST_ERROR"})
     @Operation(summary = "소셜/로컬 통합 로그인", description = "소셜/로컬 통합 로그인 로직을 처리합니다.")
     public ResponseEntity<ApiResponse<AuthResponseDTO.LoginResponseDTO>> login(@RequestBody @Valid AuthRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
 
     @ApiErrorCodeExamples(
-            value = {AuthErrorCode.class,MemberErrorCode.class},
-            include = {"EMAIL_PATTERN_ERROR", "PHONENUMBER_PATTERN_ERROR", "PASSWORD_PATTERN_ERROR", "NICKNAME_INVALID_PATTERN"})
+            value = {AuthErrorCode.class,MemberErrorCode.class, ApiErrorCode.class},
+            include = {"EMAIL_PATTERN_ERROR", "PHONENUMBER_PATTERN_ERROR", "PASSWORD_PATTERN_ERROR", "NICKNAME_INVALID_PATTERN","SIZE_ERROR",
+            "EMPTY_FIELD_ERROR"})
     @Operation(summary = "소셜/로컬 통합 회원가입", description = "소셜/로컬 통합 회원가입 로직을 처리합니다. ")
     public ResponseEntity<ApiResponse<AuthResponseDTO.SignupResponseDTO>> signup(@RequestBody @Valid AuthRequestDTO.SignupRequestDTO request, HttpServletResponse response);
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, ApiErrorCode.class},
-            include = {"EMAIL_PATTERN_ERROR", "ALREADY_EXIST_EMAIL"})
+            include = {"EMAIL_PATTERN_ERROR", "ALREADY_EXIST_EMAIL", "EMPTY_FILED_ERROR"})
     @Operation(summary = "인증 이메일 전송", description = "인증용 링크가 포함된 이메일을 전송합니다. ")
     public ResponseEntity<ApiResponse<String>> sendEmail(@RequestBody @Valid AuthRequestDTO.EmailRequestDTO request) throws MessagingException, IOException;
 

--- a/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
@@ -10,23 +10,22 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorCode implements BaseErrorCode {
 
     // 유효성 검사
-    INVALID_EMAIL_FORMAT("INVALID_EMAIL_FORMAT", HttpStatus.BAD_REQUEST, "이메일 형식이 잘못되었습니다."),
-    INVALID_PHONE_NUMBER_PATTERN("INVALID_PATTERN", HttpStatus.BAD_REQUEST, "형식이 올바르지 않습니다."),
-    INVALID_PASSWORD_FORMAT("INVALID_PASSWORD_FORMAT", HttpStatus.BAD_REQUEST, "비밀번호 형식이 잘못되었습니다."),
+    EMAIL_INVALID_FORMAT_ERROR("EMAIL_INVALID_FORMAT_ERROR", HttpStatus.BAD_REQUEST, "이메일 형식이 잘못되었습니다."),
+    PHONENUMBER_PATTERN_ERROR("PHONENUMBER_PATTERN_ERROR", HttpStatus.BAD_REQUEST, "전화번호 형식이 올바르지 않습니다."),
+    PASSWORD_PATTERN_ERROR("PASSWORD_PATTERN_ERROR", HttpStatus.BAD_REQUEST, "비밀번호 형식이 잘못되었습니다."),
 
     // 카카오 로그인
-    KAKAO_INVALID_AUTHORIZATION_CODE("KAKAO_INVALID_AUTHORIZATION_CODE", HttpStatus.BAD_REQUEST, "유효하지 않은 Authorization Code입니다."),
-    KAKAO_AUTH_FAILED("KAKAO_AUTH_FAILED", HttpStatus.UNAUTHORIZED, "카카오 인증 요청이 실패했습니다."),
+    KAKAO_REQUEST_ERROR("KAKAO_REQUEST_ERROR", HttpStatus.UNAUTHORIZED, "카카오 인증 요청이 실패했습니다."),
 
     // JWT 토큰
-    INVALID_TOKEN("INVALID_TOKEN", HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다."),
-    IN_BLACK_LIST("IN_BLACK_LIST", HttpStatus.UNAUTHORIZED, "블랙리스트에 포함된 토큰입니다."),
-    EXPIRED_TOKEN("EXPIRED_TOKEN", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_INVALID_ERROR("TOKEN_INVALID_ERROR", HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다."),
+    TOKEN_BLACK_LIST_ERROR("TOKEN_BLACK_LIST_ERROR", HttpStatus.UNAUTHORIZED, "블랙리스트에 포함된 토큰입니다."),
+    TOKEN_EXPIRED_ERROR("TOKEN_EXPIRED_ERROR", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
 
     // 이메일
-    ALREADY_EXIST_EMAIL("ALREADY_EXIST_EMAIL", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-    NOT_VERIFIED_EMAIL("NOT_VERIFIED_EMAIL", HttpStatus.BAD_REQUEST, "인증된 이메일이 아닙니다."),
-    EXPIRED_LINK("EXPIRED_LINK", HttpStatus.BAD_REQUEST, "인증 링크 시간이 만료되었습니다."),
+    EMAIL_DUPLICATE_ERROR("EMAIL_DUPLICATE_ERROR", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    EMAIL_VERIFICATION_ERROR("EMAIL_VERIFICATION_ERROR", HttpStatus.BAD_REQUEST, "인증된 이메일이 아닙니다."),
+    LINK_EXPIRED_ERROR("LINK_EXPIRED_ERROR", HttpStatus.BAD_REQUEST, "인증 링크 시간이 만료되었습니다."),
     EMAIL_PATTERN_ERROR("EMAIL_PATTERN_ERROR", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
     ;
 

--- a/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
@@ -74,7 +74,7 @@ public class EmailService {
 
     // 이메일 중복 검사
     public void existEmail(String toEmail) {
-        if(Boolean.TRUE.equals(memberRepository.existsByEmail(toEmail))) throw new AuthException(AuthErrorCode.ALREADY_EXIST_EMAIL);
+        if(Boolean.TRUE.equals(memberRepository.existsByEmail(toEmail))) throw new AuthException(AuthErrorCode.EMAIL_DUPLICATE_ERROR);
     }
 
     // 이메일의 인증 상태 반환
@@ -87,7 +87,7 @@ public class EmailService {
     public void isVerified(String email) {
         Boolean isVerified = emailRepository.existsByEmailAndVerifyStatus(email, true);
 
-        if(Boolean.FALSE.equals(isVerified)) throw new AuthException(AuthErrorCode.NOT_VERIFIED_EMAIL);
+        if(Boolean.FALSE.equals(isVerified)) throw new AuthException(AuthErrorCode.EMAIL_VERIFICATION_ERROR);
     }
 
     // 이메일 인증 (boolean 형으로 변경 예정)
@@ -97,7 +97,7 @@ public class EmailService {
         byEmailAndVerifyCode.ifPresent(emailVerification -> {
             // 링크 시간이 만료된 경우
             if(LocalDateTime.now().isAfter(emailVerification.getExpireDate())){
-                throw new AuthException(AuthErrorCode.EXPIRED_LINK);
+                throw new AuthException(AuthErrorCode.LINK_EXPIRED_ERROR);
             }
 
             // 링크 시간이 만료되지 않았으면 인증

--- a/src/main/java/oncog/cogroom/domain/auth/service/session/AuthSessionService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/session/AuthSessionService.java
@@ -43,7 +43,7 @@ public class AuthSessionService extends BaseService {
 
         Long memberId = jwtProvider.extractMemberId(refreshToken);
 
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND_ERROR));
 
         // 토큰 생성
         AuthResponseDTO.ServiceTokenDTO tokenDTO = tokenUtil.createTokens(member);

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
@@ -53,7 +53,7 @@ public class KakaoAuthService extends AbstractAuthService {
             return response.getBody().getAccessToken();
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             log.error("카카오 액세스 토큰 요청 실패 : {}", e.getResponseBodyAsString());
-            throw new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED);
+            throw new AuthException(AuthErrorCode.KAKAO_REQUEST_ERROR);
         }
     }
 
@@ -74,7 +74,7 @@ public class KakaoAuthService extends AbstractAuthService {
 
         } catch (HttpClientErrorException e) {
             log.error("Kakao 사용자 정보 조회 API 호출 실패: 상태 코드 {}, 응답 본문 {}", e.getStatusCode(), e.getResponseBodyAsString());
-            throw new AuthException(AuthErrorCode.KAKAO_AUTH_FAILED);
+            throw new AuthException(AuthErrorCode.KAKAO_REQUEST_ERROR);
         }
     }
 

--- a/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/daily/controller/docs/DailyControllerDocs.java
@@ -19,20 +19,20 @@ public interface DailyControllerDocs {
     @Operation(summary = "데일리 질문 조회", description = "멤버가 할당받은 데일리 질문을 조회합니다.")
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
-            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "INTERNAL_SERVER_ERROR"})
+            include = {"MEMBER_NOT_FOUND_ERROR", "QUESTION_NOT_FOUND_ERROR", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<DailyQuestionResponseDTO>> getDailyQuestion();
 
     @Operation(summary = "데일리 답변 등록", description = "데일리 질문에 대한 답변을 등록합니다.")
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
-            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "ALREADY_ANSWERED", "EMPTY_FILED",
-                    "ASSIGNED_QUESTION_NOT_FOUND", "ANSWER_LENGTH_EXCEEDED", "ANSWER_TIME_EXPIRED", "INTERNAL_SERVER_ERROR"})
+            include = {"MEMBER_NOT_FOUND_ERROR", "QUESTION_NOT_FOUND_ERROR", "ANSWER_ALREADY_EXIST_ERROR", "EMPTY_FILED_ERROR",
+                    "ASSIGNED_QUESTION_NOT_FOUND_ERROR", "ANSWER_LENGTH_EXCEEDED_ERROR", "ANSWER_TIME_EXPIRED_ERROR", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<String>> createDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request);
 
     @Operation(summary = "데일리 답변 수정", description = "데일리 질문에 대한 답변을 수정합니다.")
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, DailyErrorCode.class, ApiErrorCode.class},
-            include = {"MEMBER_NOT_FOUND", "DAILY_QUESTION_NOT_FOUND", "ALREADY_ANSWERED", "EMPTY_FILED",
-                    "ASSIGNED_QUESTION_NOT_FOUND", "ANSWER_LENGTH_EXCEEDED", "ANSWER_TIME_EXPIRED", "INTERNAL_SERVER_ERROR"})
+            include = {"MEMBER_NOT_FOUND_ERROR", "QUESTION_NOT_FOUND_ERROR", "ANSWER_ALREADY_EXIST_ERROR", "EMPTY_FILED_ERROR",
+                    "ASSIGNED_QUESTION_NOT_FOUND_ERROR", "ANSWER_LENGTH_EXCEEDED_ERROR", "ANSWER_TIME_EXPIRED_ERROR", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<String>> updateDailyAnswer(@RequestBody @Valid DailyAnswerRequestDTO request);
 }

--- a/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/daily/exception/DailyErrorCode.java
@@ -9,13 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum DailyErrorCode implements BaseErrorCode {
 
-    DAILY_QUESTION_NOT_FOUND("DAILY_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 질문을 찾을 수 없습니다."),
-    ASSIGNED_QUESTION_NOT_FOUND("ASSIGNED_QUESTION_NOT_FOUND", HttpStatus.NOT_FOUND, "해당 id를 가진 할당된 데일리 질문을 찾을 수 없습니다."),
-    ALREADY_ANSWERED("ALREADY_ANSWERED", HttpStatus.CONFLICT, "이미 답변이 존재합니다."),
-    ANSWER_LENGTH_EXCEEDED("ANSWER_LENGTH_EXCEEDED", HttpStatus.BAD_REQUEST, "답변은 100자 이하여야 합니다."),
-    ANSWER_TIME_EXPIRED("ANSWER_TIME_EXPIRED", HttpStatus.FORBIDDEN, "오늘 할당된 질문에만 답변을 작성 및 수정할 수 있습니다."),
-    ANSWER_NOT_FOUND("ANSWER_NOT_FOUND", HttpStatus.NOT_FOUND, "데일리 답변을 찾을 수 없습니다."),
-    INVALID_QNA_CONSTRUCTION("INVALID_QNA_CONSTRUCTION", HttpStatus.INTERNAL_SERVER_ERROR, "질문 - 답변 데이터를 구성하는 중 문제가 발생했습니다.");
+    QUESTION_NOT_FOUND_ERROR("QUESTION_NOT_FOUND_ERROR", HttpStatus.NOT_FOUND, "데일리 질문을 찾을 수 없습니다."),
+    ASSIGNED_QUESTION_NOT_FOUND_ERROR("ASSIGNED_QUESTION_NOT_FOUND_ERROR", HttpStatus.NOT_FOUND, "해당 id를 가진 할당된 데일리 질문을 찾을 수 없습니다."),
+    ANSWER_ALREADY_EXIST_ERROR("ANSWER_ALREADY_EXIST_ERROR", HttpStatus.CONFLICT, "이미 답변이 존재합니다."),
+    ANSWER_LENGTH_EXCEEDED_ERROR("ANSWER_LENGTH_EXCEEDED_ERROR", HttpStatus.BAD_REQUEST, "답변은 100자 이하여야 합니다."),
+    ANSWER_TIME_EXPIRED_ERROR("ANSWER_TIME_EXPIRED_ERROR", HttpStatus.FORBIDDEN, "오늘 할당된 질문에만 답변을 작성 및 수정할 수 있습니다."),
+    ANSWER_NOT_FOUND_ERROR("ANSWER_NOT_FOUND_ERROR", HttpStatus.NOT_FOUND, "데일리 답변을 찾을 수 없습니다."),
+    QNA_NOT_FOUND_ERROR("QNA_NOT_FOUND_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "질문 - 답변 데이터를 구성하는 중 문제가 발생했습니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/oncog/cogroom/domain/daily/service/DailyQuestionAssignService.java
+++ b/src/main/java/oncog/cogroom/domain/daily/service/DailyQuestionAssignService.java
@@ -64,7 +64,7 @@ public class DailyQuestionAssignService {
     @Transactional
     public void assignDailyQuestionAtSignup(Provider provider, String providerId) {
         Member member = memberRepository.findByProviderAndProviderId(provider, providerId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND_ERROR));
         assignDailyQuestion(member);
     }
 

--- a/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
+++ b/src/main/java/oncog/cogroom/domain/daily/service/DailyService.java
@@ -92,7 +92,7 @@ public class DailyService extends BaseService {
 
         List<DailyQuestionResponseDTO.AssignedQuestionWithAnswerDTO> response =
                 assignedQuestionRepository.findAssignedQuestionsWithAnswerByMember(jwtProvider.extractMemberId())
-                .orElseThrow(() -> new DailyException(DailyErrorCode.ANSWER_NOT_FOUND));
+                .orElseThrow(() -> new DailyException(DailyErrorCode.ANSWER_NOT_FOUND_ERROR));
 
         // 데일리 질문이 할당된 시간이 00:00:00 ~ 23:59:59 내로 할당되었는지 검사
         response.forEach(res -> {
@@ -121,17 +121,17 @@ public class DailyService extends BaseService {
         LocalDateTime startOfToday = getStartOfToday();
         LocalDateTime endOfToday = getEndOfToday();
         return assignedQuestionRepository.findByMemberAndAssignedDateGreaterThanEqualAndAssignedDateLessThan(member, startOfToday, endOfToday)
-                .orElseThrow(() -> new DailyException(DailyErrorCode.DAILY_QUESTION_NOT_FOUND));
+                .orElseThrow(() -> new DailyException(DailyErrorCode.QUESTION_NOT_FOUND_ERROR));
     }
 
     private AssignedQuestion getAssignedQuestion(Member member, Long assignedQuestionId) {
         return assignedQuestionRepository.findByMemberAndId(member, assignedQuestionId)
-                .orElseThrow(() -> new DailyException(DailyErrorCode.ASSIGNED_QUESTION_NOT_FOUND));
+                .orElseThrow(() -> new DailyException(DailyErrorCode.ASSIGNED_QUESTION_NOT_FOUND_ERROR));
     }
 
     private Answer getDailyAnswer(Member member, LocalDateTime start, LocalDateTime end) {
         return answerRepository.findByMemberAndCreatedAtBetween(member, start, end)
-                .orElseThrow(() -> new DailyException(DailyErrorCode.ANSWER_NOT_FOUND));
+                .orElseThrow(() -> new DailyException(DailyErrorCode.ANSWER_NOT_FOUND_ERROR));
     }
 
     // 금일 시작 시간 조회 (00:00:00)
@@ -160,7 +160,7 @@ public class DailyService extends BaseService {
 
     private void checkDuplicateAnswer(Member member, Question question) {
         if (answerRepository.existsByMemberAndQuestion(member, question)) {
-            throw new DailyException(DailyErrorCode.ALREADY_ANSWERED);
+            throw new DailyException(DailyErrorCode.ANSWER_ALREADY_EXIST_ERROR);
         }
     }
 
@@ -175,7 +175,7 @@ public class DailyService extends BaseService {
         log.info("now: {}, target: {}", now, target);
         if (!now.toLocalDate().isEqual(target.toLocalDate())) {
             log.info("날짜가 일치하지 않습니다.");
-            throw new DailyException(DailyErrorCode.ANSWER_TIME_EXPIRED);
+            throw new DailyException(DailyErrorCode.ANSWER_TIME_EXPIRED_ERROR);
         }
     }
 

--- a/src/main/java/oncog/cogroom/domain/member/controller/MemberController.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/MemberController.java
@@ -36,8 +36,8 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @GetMapping("/summary")
-    public ResponseEntity<ApiResponse<MemberSummaryDTO>> getMemberSummary(HttpServletRequest request) {
-        MemberSummaryDTO memberSummary = memberService.findMemberSummary(request);
+    public ResponseEntity<ApiResponse<MemberSummaryDTO>> getMemberSummary() {
+        MemberSummaryDTO memberSummary = memberService.findMemberSummary();
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS,memberSummary));
     }

--- a/src/main/java/oncog/cogroom/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/docs/MemberControllerDocs.java
@@ -2,7 +2,6 @@ package oncog.cogroom.domain.member.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import oncog.cogroom.domain.auth.exception.AuthErrorCode;
 import oncog.cogroom.domain.daily.dto.response.DailyQuestionResponseDTO;
@@ -12,10 +11,8 @@ import oncog.cogroom.domain.member.dto.MemberResponseDTO;
 import oncog.cogroom.domain.member.exception.MemberErrorCode;
 import oncog.cogroom.global.common.response.ApiResponse;
 import oncog.cogroom.global.common.response.code.ApiErrorCode;
-import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import oncog.cogroom.global.exception.swagger.ApiErrorCodeExamples;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
@@ -25,26 +22,27 @@ public interface MemberControllerDocs {
 
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, AuthErrorCode.class},
-            include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND"})
+            include = {"TOKEN_INVALID_ERROR","TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR"})
     @Operation(summary = "사용자 정보 조회 API", description = "사용자 정보 수정을 위해 사용자 정보를 조회합니다. ")
     ResponseEntity<ApiResponse<MemberResponseDTO.MemberInfoDTO>> getMemberInfo();
 
     @ApiErrorCodeExamples(
-            value = {MemberErrorCode.class, AuthErrorCode.class},
-            include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND",
-                    "PHONENUMBER_PATTERN_ERROR", "PASSWORD_PATTERN_ERROR", "NICKNAME_INVALID_PATTERN" ,"DUPLICATE_USER_NICKNAME"})
+            value = {MemberErrorCode.class, AuthErrorCode.class, ApiErrorCode.class},
+            include = {"TOKEN_INVALID_ERROR","TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR",
+                    "PHONENUMBER_PATTERN_ERROR", "PASSWORD_PATTERN_ERROR" ,"NICKNAME_DUPLICATE_ERROR",
+            "EMPTY_FILED_ERROR"})
     @Operation(summary = "사용자 정보 수정 API", description = "사용자 정보를 수정합니다. ")
     ResponseEntity<ApiResponse<Void>> updateMemberInfo(@RequestBody @Valid MemberRequestDTO.MemberInfoUpdateDTO request);
 
     @ApiErrorCodeExamples(
             value = {ApiErrorCode.class, MemberErrorCode.class},
-            include = {"EMPTY_FILED", "DUPLICATE_USER_NICKNAME"})
+            include = {"NICKNAME_DUPLICATE_ERROR", "EMPTY_FILED_ERROR"})
     @Operation(summary = "닉네임 중복검사 API", description = "닉네임 중복 검사를 진행합니다.")
     ResponseEntity<ApiResponse<Boolean>> existNickname(@RequestBody @Valid MemberRequestDTO.ExistNicknameDTO request);
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class},
-            include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND"}
+            include = {"TOKEN_INVALID_ERROR","TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR"}
     )
     @Operation(summary = "사용자 정보 조회 API(닉네임,사진)", description = "사용자의 닉네임과 이미지 조회를 진행합니다.")
     ResponseEntity<ApiResponse<MemberResponseDTO.MemberSummaryDTO>> getMemberSummary();
@@ -52,15 +50,15 @@ public interface MemberControllerDocs {
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class},
-            include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND"}
+            include = {"TOKEN_INVALID_ERROR","TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR"}
     )
     @Operation(summary = "사용자 정보 조회 API(마이페이지)", description = "마이페이지 홈에서 필요한 사용자의 정보 조회를 진행합니다.")
     ResponseEntity<ApiResponse<MemberResponseDTO.MemberMyPageInfoDTO>> getMemberInfoForMyPage();
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class, DailyErrorCode.class},
-            include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND",
-             "INVALID_QNA_CONSTRUCTION"}
+            include = {"TOKEN_INVALID_ERROR","TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR",
+             "QNA_NOT_FOUND_ERROR"}
     )
     @Operation(summary = "데일리 질문 및 답변 조회", description = "마이페이지 내에서 사용자에게 할당된 데일리 질문과 그에 대한 답변을 조회합니다.")
     public ResponseEntity<ApiResponse<List<DailyQuestionResponseDTO.AssignedQuestionWithAnswerDTO>>> getDailyQuestionAndAnswer();

--- a/src/main/java/oncog/cogroom/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/member/controller/docs/MemberControllerDocs.java
@@ -47,7 +47,7 @@ public interface MemberControllerDocs {
             include = {"INVALID_TOKEN","EXPIRED_TOKEN", "MEMBER_NOT_FOUND"}
     )
     @Operation(summary = "사용자 정보 조회 API(닉네임,사진)", description = "사용자의 닉네임과 이미지 조회를 진행합니다.")
-    ResponseEntity<ApiResponse<MemberResponseDTO.MemberSummaryDTO>> getMemberSummary(HttpServletRequest request);
+    ResponseEntity<ApiResponse<MemberResponseDTO.MemberSummaryDTO>> getMemberSummary();
 
 
     @ApiErrorCodeExamples(

--- a/src/main/java/oncog/cogroom/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/member/exception/MemberErrorCode.java
@@ -8,9 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum MemberErrorCode implements BaseErrorCode {
-    DUPLICATE_USER_NICKNAME("DUPLICATE_USER_NICKNAME", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
-    NICKNAME_INVALID_PATTERN("NICKNAME_INVALID_PATTERN", HttpStatus.BAD_REQUEST,"닉네임은 숫자로만 구성될 수 없습니다."),
-    MEMBER_NOT_FOUND("MEMBER_NOT_FOUND", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NICKNAME_DUPLICATE_ERROR("NICKNAME_DUPLICATE_ERROR", HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+    NICKNAME_INVALID_PATTERN("NICKNAME_INVALID_PATTERN", HttpStatus.BAD_REQUEST,"닉네임은 형식이 잘못되었습니다."),
+    MEMBER_NOT_FOUND_ERROR("MEMBER_NOT_FOUND_ERROR", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     PASSWORD_PATTERN_ERROR("PASSWORD_PATTERN_ERROR", HttpStatus.BAD_REQUEST, "비밀번호는 영문 소문자, 대문자, 특수 문자로 구성되어야 합니다."),
     PHONENUMBER_PATTERN_ERROR("PHONENUMBER_PATTERN_ERROR", HttpStatus.BAD_REQUEST, "닉네임은 한글,영문,숫자만 사용할 수 있습니다."),
     SIZE_ERROR("SIZE_ERROR", HttpStatus.BAD_REQUEST, "길이가 초과되었습니다.");

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -45,12 +45,9 @@ public class MemberService extends BaseService {
                 .build();
     }
 
-    public MemberSummaryDTO findMemberSummary(HttpServletRequest request) {
+    public MemberSummaryDTO findMemberSummary() {
         Member member = getMember();
 
-        // 테스트용 다음 이슈에서 삭제 예정
-        String accessToken = jwtProvider.resolveToken(request);
-        log.info("now accessToken = {}", accessToken);
 
         return MemberSummaryDTO.builder()
                 .imageUrl(member.getProfileImageUrl())

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package oncog.cogroom.domain.member.service;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.auth.service.EmailService;
@@ -86,7 +85,7 @@ public class MemberService extends BaseService {
     public boolean existNickname(MemberRequestDTO.ExistNicknameDTO request) {
 
         if(Boolean.TRUE.equals(memberRepository.existsByNickname(request.getNickname()))){
-            throw new MemberException(MemberErrorCode.DUPLICATE_USER_NICKNAME);
+            throw new MemberException(MemberErrorCode.NICKNAME_DUPLICATE_ERROR);
         }
 
         return false;

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -10,7 +10,6 @@ import oncog.cogroom.domain.member.exception.MemberException;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.domain.streak.service.StreakService;
 import oncog.cogroom.global.common.service.BaseService;
-import oncog.cogroom.global.security.jwt.JwtProvider;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +28,6 @@ public class MemberService extends BaseService {
     private final StreakService streakService;
     private final EmailService emailService;
 
-    // 테스트용 다음 이슈에서 삭제 예정
-    private final JwtProvider jwtProvider;
-
     public MemberInfoDTO findMemberInfo() {
         Member member = getMember();
 
@@ -46,7 +42,6 @@ public class MemberService extends BaseService {
 
     public MemberSummaryDTO findMemberSummary() {
         Member member = getMember();
-
 
         return MemberSummaryDTO.builder()
                 .imageUrl(member.getProfileImageUrl())
@@ -73,9 +68,6 @@ public class MemberService extends BaseService {
 
     public void updateMemberInfo(MemberRequestDTO.MemberInfoUpdateDTO request){
         Member member = getMember();
-
-        // 닉네임 숫자로만 구성되어있는지 검사
-        if(request.getNickname().matches("^\\d+$")) throw new MemberException(MemberErrorCode.NICKNAME_INVALID_PATTERN);
 
         emailService.isVerified(request.getEmail());
 

--- a/src/main/java/oncog/cogroom/domain/streak/controller/docs/StreakControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/streak/controller/docs/StreakControllerDocs.java
@@ -15,6 +15,6 @@ public interface StreakControllerDocs {
     @Operation(summary = "물방울(스트릭) 기록 조회", description = "물방울 기록을 리스트로 반환합니다.")
     @ApiErrorCodeExamples(
             value = {MemberErrorCode.class, ApiErrorCode.class},
-            include = {"MEMBER_NOT_FOUND", "INTERNAL_SERVER_ERROR"})
+            include = {"MEMBER_NOT_FOUND_ERROR", "INTERNAL_SERVER_ERROR"})
     ResponseEntity<ApiResponse<StreakCalendarResponseDTO>> getStreakCalendar();
 }

--- a/src/main/java/oncog/cogroom/global/common/response/code/ApiErrorCode.java
+++ b/src/main/java/oncog/cogroom/global/common/response/code/ApiErrorCode.java
@@ -9,8 +9,9 @@ import org.springframework.http.HttpStatus;
 public enum ApiErrorCode implements BaseErrorCode {
 
     // 시스템
-    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
-    BAD_REQUEST("BAD_REQUEST", HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    EMPTY_FIELD_ERROR("EMPTY_FIELD_ERROR", HttpStatus.BAD_REQUEST, "요청 필드가 비어있습니다."),
+    BAD_REQUEST_ERROR("BAD_REQUEST_ERROR", HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/oncog/cogroom/global/common/service/BaseService.java
+++ b/src/main/java/oncog/cogroom/global/common/service/BaseService.java
@@ -17,6 +17,6 @@ public abstract class BaseService {
 
     protected Member getMember() {
         return memberRepository.findById(jwtProvider.extractMemberId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND_ERROR));
     }
 }

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         BaseErrorCode errorCode = (BaseErrorCode) (request.getAttribute("errorCode"));
 
         if (errorCode == null) {
-            errorCode = AuthErrorCode.INVALID_TOKEN;
+            errorCode = AuthErrorCode.TOKEN_INVALID_ERROR;
         }
 
         ApiErrorResponse errorResponse = ApiErrorResponse.of(errorCode);

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtProvider.java
@@ -62,16 +62,16 @@ public class JwtProvider {
             String key = "BL:" + DigestUtils.sha256Hex(token);
             if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
                 log.warn("JWT Token is blackListed: {}", token);
-                throw new AuthException(AuthErrorCode.IN_BLACK_LIST);
+                throw new AuthException(AuthErrorCode.TOKEN_BLACK_LIST_ERROR);
             }
 
             return true;
         }catch(ExpiredJwtException e){
             log.error("Expired JWT token: {}", e.getMessage());
-            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+            throw new AuthException(AuthErrorCode.TOKEN_EXPIRED_ERROR);
         } catch (JwtException | IllegalArgumentException e) {
             log.error("Invalid JWT token : {}", e.getMessage());
-            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.TOKEN_INVALID_ERROR);
         }
     }
     public Claims getClaims(String token) {

--- a/src/main/java/oncog/cogroom/global/security/service/CustomUserDetailService.java
+++ b/src/main/java/oncog/cogroom/global/security/service/CustomUserDetailService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         Member member = memberRepository.findById(Long.valueOf(userId))
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND_ERROR));
 
         log.info("사용자 조회 완료");
 


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #97 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 에러 코드 네이밍 통일 (Field 이름 + 에러 이름 + ERROR) 형식
- 닉네임 숫자 구성 검사를 서비스 코드에서 어노테이션이 하도록 변경

## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
## 이번 PR은 배포 후 스웨거로 확인하는게 좋을 것 같습니다! 1차로 확인은 했는데 수정 사항 생기면 추가 후 PR해서 올리도록 하겠습니다.
