### PR TITLE
[REFACTOR] preSignedUrl 로직 수정 및 시큐리티 에러 수정

### DIFF
--- a/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/oncog/cogroom/domain/auth/exception/AuthErrorCode.java
@@ -21,6 +21,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     TOKEN_INVALID_ERROR("TOKEN_INVALID_ERROR", HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다."),
     TOKEN_BLACK_LIST_ERROR("TOKEN_BLACK_LIST_ERROR", HttpStatus.UNAUTHORIZED, "블랙리스트에 포함된 토큰입니다."),
     TOKEN_EXPIRED_ERROR("TOKEN_EXPIRED_ERROR", HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    TOKEN_EMPTY_ERROR("TOKEN_EMPTY_ERROR", HttpStatus.UNAUTHORIZED, "토큰이 헤더에 존재하지 않습니다"),
 
     // 이메일
     EMAIL_DUPLICATE_ERROR("EMAIL_DUPLICATE_ERROR", HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),

--- a/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
+++ b/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
@@ -63,7 +63,8 @@ public class SecurityConfig {
                 antMatcher("/api/v1/auth/logout"),
                 antMatcher("/api/v1/members/**"),
                 antMatcher("/api/v1/streaks/**"),
-                antMatcher("/api/v1/daily/**")
+                antMatcher("/api/v1/daily/**"),
+                antMatcher("/api/v1/files/**")
         );
         return requestMatchers.toArray(RequestMatcher[]::new);
     }

--- a/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/S3Controller.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import oncog.cogroom.global.common.response.ApiResponse;
 import oncog.cogroom.global.common.response.code.ApiSuccessCode;
 import oncog.cogroom.global.s3.dto.S3RequestDTO;
+import oncog.cogroom.global.s3.dto.S3ResponseDTO;
 import oncog.cogroom.global.s3.service.S3Service;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,11 +19,17 @@ public class S3Controller {
     private final S3Service s3Service;
 
     @PostMapping("/preSigned-url/upload")
-    public ResponseEntity<ApiResponse<List<String>>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
-        List<String> preSignedUrls = s3Service.generatePreSignedUrl(request);
+    public ResponseEntity<ApiResponse<List<S3ResponseDTO.PreSignedResponseDTO>>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request) {
+        List<S3ResponseDTO.PreSignedResponseDTO> preSignedUrls = s3Service.generatePreSignedUrl(request);
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS,preSignedUrls));
     }
 
+    @DeleteMapping("/preSigned-url")
+    public ResponseEntity<ApiResponse<Void>> deleteFile(@RequestBody S3RequestDTO.DeleteFilesDTO request) {
+        s3Service.deleteFile(request);
+
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
+    }
 
 }

--- a/src/main/java/oncog/cogroom/global/s3/controller/docs/S3ControllerDocs.java
+++ b/src/main/java/oncog/cogroom/global/s3/controller/docs/S3ControllerDocs.java
@@ -1,0 +1,33 @@
+package oncog.cogroom.global.s3.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import oncog.cogroom.domain.auth.exception.AuthErrorCode;
+import oncog.cogroom.global.common.response.ApiResponse;
+import oncog.cogroom.global.common.response.code.ApiErrorCode;
+import oncog.cogroom.global.exception.swagger.ApiErrorCodeExamples;
+import oncog.cogroom.global.s3.dto.S3RequestDTO;
+import oncog.cogroom.global.s3.dto.S3ResponseDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "S3", description = "S3 관련 API")
+public interface S3ControllerDocs {
+    @Operation(summary = "PreSignedUrl 요청", description = "PreSignedUrl과 accessUrl을 요청합니다.")
+    @ApiErrorCodeExamples(
+            value = {AuthErrorCode.class, ApiErrorCode.class},
+            include = {"INTERNAL_SERVER_ERROR", "TOKEN_INVALID_ERROR", "TOKEN_BLACK_LIST_ERROR", "TOKEN_EXPIRED_ERROR" ,"TOKEN_EMPTY_ERROR"})
+
+    ResponseEntity<ApiResponse<List<S3ResponseDTO.PreSignedResponseDTO>>> getPreSignedUrl(@RequestBody S3RequestDTO.PreSignedUrlRequestDTO request);
+
+    @Operation(summary = "S3 파일 삭제", description = "S3에 존재하는 파일 삭제를 요청합니다. (백엔드 테스트용)")
+    @ApiErrorCodeExamples(
+            value = {AuthErrorCode.class, ApiErrorCode.class},
+            include = {"INTERNAL_SERVER_ERROR", "TOKEN_INVALID_ERROR", "TOKEN_BLACK_LIST_ERROR", "TOKEN_EXPIRED_ERROR" ,"TOKEN_EMPTY_ERROR"})
+
+
+    ResponseEntity<ApiResponse<Void>> deleteFile(@RequestBody S3RequestDTO.DeleteFilesDTO request);
+
+}

--- a/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
+++ b/src/main/java/oncog/cogroom/global/s3/dto/S3RequestDTO.java
@@ -2,7 +2,9 @@ package oncog.cogroom.global.s3.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import oncog.cogroom.global.s3.enums.UploadType;
 
+import java.util.List;
 import java.util.Map;
 
 public class S3RequestDTO {
@@ -11,5 +13,12 @@ public class S3RequestDTO {
     @Getter
     public static class PreSignedUrlRequestDTO {
         private Map<String, String> fileSet;
+        private UploadType uploadType;
+    }
+
+    @Builder
+    @Getter
+    public static class DeleteFilesDTO{
+        private List<String> fileUrls;
     }
 }

--- a/src/main/java/oncog/cogroom/global/s3/dto/S3ResponseDTO.java
+++ b/src/main/java/oncog/cogroom/global/s3/dto/S3ResponseDTO.java
@@ -1,0 +1,14 @@
+package oncog.cogroom.global.s3.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class S3ResponseDTO {
+
+    @Getter
+    @Builder
+    public static class PreSignedResponseDTO {
+        private String preSignedUrl;
+        private String accessUrl;
+    }
+}

--- a/src/main/java/oncog/cogroom/global/s3/enums/UploadType.java
+++ b/src/main/java/oncog/cogroom/global/s3/enums/UploadType.java
@@ -1,0 +1,5 @@
+package oncog.cogroom.global.s3.enums;
+
+public enum UploadType {
+    PROFILE, CONTENT
+}

--- a/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
+++ b/src/main/java/oncog/cogroom/global/s3/service/S3Service.java
@@ -2,7 +2,12 @@ package oncog.cogroom.global.s3.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.member.exception.MemberException;
+import oncog.cogroom.global.common.response.code.ApiErrorCode;
 import oncog.cogroom.global.s3.dto.S3RequestDTO;
+import oncog.cogroom.global.s3.dto.S3ResponseDTO;
+import oncog.cogroom.global.s3.enums.UploadType;
+import oncog.cogroom.global.security.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +33,7 @@ public class S3Service {
 
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
+    private final JwtProvider jwtProvider;
 
     @Value("${aws.s3.bucket}")
     private String bucket;
@@ -35,32 +41,19 @@ public class S3Service {
     @Value("${aws.s3.cloud-front}")
     private String cloudFrontUrl;
 
-    // 단일 파일 업로드
-    public String generatePreSignedUrl(String fileName, String contentType) {
-        PutObjectRequest uploadFile = PutObjectRequest.builder()
-                .bucket(bucket)
-                .key(fileName)
-                .contentType(contentType)
-                .build();
 
-        PutObjectPresignRequest preSignRequest = PutObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(10))
-                .putObjectRequest(uploadFile)
-                .build();
+    // PreSignedUrl 생성
+    public List<S3ResponseDTO.PreSignedResponseDTO> generatePreSignedUrl(S3RequestDTO.PreSignedUrlRequestDTO request) {
 
-        PresignedPutObjectRequest preSignedRequest = s3Presigner.presignPutObject(preSignRequest);
+        return request.getFileSet()
+                .entrySet()
+                .stream()
+                .map(file -> {
 
-        return preSignedRequest.url().toString();
-    }
-
-    // 복수 파일 업로드
-    public List<String> generatePreSignedUrl(S3RequestDTO.PreSignedUrlRequestDTO request) {
-
-        return request.getFileSet().entrySet().stream().map(file -> {
             // 업로드 파일 요청 생성
             PutObjectRequest uploadFile = PutObjectRequest.builder()
                     .bucket(bucket)
-                    .key(file.getKey())
+                    .key(generateKey(file.getKey(), request.getUploadType()))
                     .contentType(file.getValue())
                     .build();
 
@@ -70,7 +63,14 @@ public class S3Service {
                     .putObjectRequest(uploadFile)
                     .build();
 
-            return s3Presigner.presignPutObject(preSignRequest).url().toString();
+            String preSignedUrl = s3Presigner.presignPutObject(preSignRequest).url().toString();
+            String accessUrl = generateAccessUrl(file.getKey(), request.getUploadType());
+
+            return S3ResponseDTO.PreSignedResponseDTO.builder()
+                    .preSignedUrl(preSignedUrl)
+                    .accessUrl(accessUrl)
+                    .build();
+
         }).collect(Collectors.toList());
     }
 
@@ -95,9 +95,11 @@ public class S3Service {
     }
 
     // s3 파일 삭제 (추후 강의 기능 적용시 변경 사항 발생 가능)
-    public void deleteFile(List<String> fileUrls) {
-        fileUrls.forEach(fileUrl -> {
+    public void deleteFile(S3RequestDTO.DeleteFilesDTO request) {
+        request.getFileUrls().forEach(fileUrl -> {
             String fileKey = extractKey(fileUrl);
+
+            log.info("fileKey = {}", fileKey);
 
             DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                     .bucket(bucket)
@@ -107,9 +109,43 @@ public class S3Service {
             s3Client.deleteObject(deleteRequest);
         });
     }
+
+
     public String extractKey(String fileUrl) {
+
         return fileUrl.replace(cloudFrontUrl, "");
     }
 
+    // 저장될 파일 이름(파일 키) 생성
+    private String generateKey(String fileName, UploadType uploadType) {
+        Long memberId = jwtProvider.extractMemberId();
+
+        switch(uploadType){
+            case PROFILE -> { // 프로필 사진일 경우 profile/memberId_파일 명.extension
+                return String.format("%s/%d_%s", uploadType, memberId, fileName);
+            }
+            case CONTENT -> { // 강의 파일인 경우 content/memberId/UUID_파일 명.extension
+                String uuid = UUID.randomUUID().toString();
+                return String.format("%s/%d/%s_%s", uploadType, memberId, uuid,fileName);
+            }
+            default -> throw new MemberException(ApiErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // CloudFront 접근 URL 생성
+    private String generateAccessUrl(String fileName, UploadType uploadType) {
+        Long memberId = jwtProvider.extractMemberId();
+
+        switch(uploadType){
+            case PROFILE -> { // 프로필 사진일 경우 profile/memberId_파일 명.extension
+                return String.format("%s/%s/%d_%s", cloudFrontUrl, uploadType.name(), memberId, fileName);
+            }
+            case CONTENT -> { // 강의 파일인 경우 content/memberId/UUID_파일 명.extension
+                String uuid = UUID.randomUUID().toString();
+                return String.format("%s/%s/%d/%s_%s", cloudFrontUrl, uploadType.name(), memberId, uuid,fileName);
+            }
+            default -> throw new MemberException(ApiErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 }

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         BaseErrorCode errorCode = (BaseErrorCode) (request.getAttribute("errorCode"));
 
         if (errorCode == null) {
-            errorCode = AuthErrorCode.TOKEN_INVALID_ERROR;
+            errorCode = AuthErrorCode.TOKEN_EMPTY_ERROR;
         }
 
         ApiErrorResponse errorResponse = ApiErrorResponse.of(errorCode);

--- a/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/oncog/cogroom/global/security/jwt/JwtAuthenticationFilter.java
@@ -40,8 +40,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                         userDetails, null, userDetails.getAuthorities());
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
-                filterChain.doFilter(request, response);
             }
+            filterChain.doFilter(request, response);
 
         } catch (AuthException e) {
             request.setAttribute("errorCode", e.getErrorCode());


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #101 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- PreSigned URL 요청시 DTO 변경 및 응답 DTO 변경
- JWT 토큰 없이 요청 보내도 통과되던 에러 수정
- 백엔드 테스트용 S3 파일 삭제 API 구현
## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
![image](https://github.com/user-attachments/assets/2ed3cf6f-49f1-4893-8f2b-987c986c86a2)

## JWT 에러
![image](https://github.com/user-attachments/assets/2336cec0-b9ad-4fed-88bf-a5629712a9ce)
### filterChain.doFilter 메소드가 if문 안에만 있어서 token이 null인 상황에 에러 처리가 정상적으로 이루어지지 않음. if문 밖으로 빼내면서 해결