### PR TITLE
[FEATURE] 사용자 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/oncog/cogroom/domain/admin/validator/AdminValidator.java
+++ b/src/main/java/oncog/cogroom/domain/admin/validator/AdminValidator.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -43,6 +44,8 @@ public class AdminValidator {
 
     // 카테고리 유효성 검사 (카테고리 존재 여부)
     public List<Category> validateCategoriesByIds(List<Integer> categoryIds) {
+        if(categoryIds == null) return Collections.emptyList();
+
         List<Category> categories = categoryRepository.findAllById(categoryIds);
 
         // 실제 존재하는 카테고리 id set

--- a/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
@@ -44,7 +44,6 @@ public class AuthController implements AuthControllerDocs {
         AuthResponse.LoginResultDTO responseExcludedToken = result.excludeTokens();
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, responseExcludedToken));
-
     }
 
 
@@ -73,7 +72,6 @@ public class AuthController implements AuthControllerDocs {
         authSessionService.logout(request);
 
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
-
     }
 
     @PostMapping("/reissue")
@@ -112,6 +110,13 @@ public class AuthController implements AuthControllerDocs {
     @PostMapping("/email/status")
     public ResponseEntity<ApiResponse<Boolean>> checkEmailVerificationStatus(@RequestBody @Valid AuthRequest.EmailDTO request) {
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, emailService.verifiedEmail(request)));
+    }
 
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdrawMember(@RequestBody AuthRequest.WithdrawDTO request,
+                                                            @RequestHeader("Authorization") String accessToken) {
+        router.withdraw(request, accessToken);
+
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
     }
 }

--- a/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
@@ -17,6 +17,7 @@ import oncog.cogroom.global.exception.swagger.ApiErrorCodeExamples;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.io.IOException;
@@ -40,13 +41,13 @@ public interface AuthControllerDocs {
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, ApiErrorCode.class},
-            include = {"EMAIL_PATTERN_ERROR", "ALREADY_EXIST_EMAIL", "EMPTY_FILED_ERROR"})
+            include = {"EMAIL_PATTERN_ERROR", "EMAIL_DUPLICATE_ERROR", "EMPTY_FILED_ERROR"})
     @Operation(summary = "인증 이메일 전송", description = "인증용 링크가 포함된 이메일을 전송합니다. ")
     public ResponseEntity<ApiResponse<String>> sendEmail(@RequestBody @Valid AuthRequest.EmailDTO request) throws MessagingException, IOException;
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, ApiErrorCode.class},
-            include = {"EMAIL_PATTERN_ERROR", "EXPIRED_LINK"})
+            include = {"EMAIL_PATTERN_ERROR", "LINK_EXPIRED_ERROR"})
     @Operation(summary = "이메일 인증", description = "링크가 클릭되었을 때 이메일을 인증합니다.")
     public ResponseEntity<ApiResponse<Void>> verifyEmail(@RequestParam String userEmail,
                                                          @RequestParam String verificationCode);
@@ -56,7 +57,7 @@ public interface AuthControllerDocs {
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class},
-            include = {"INVALID_TOKEN", "IN_BLACK_LIST", "EXPIRED_TOKEN", "MEMBER_NOT_FOUND"}
+            include = {"TOKEN_INVALID_ERROR", "TOKEN_BLACK_LIST_ERROR", "TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR_ERROR"}
     )
     @Operation(summary = "토큰 갱신 API", description = "토큰 재발급 API 입니다.")
     public ResponseEntity<ApiResponse<Void>> reIssue(@CookieValue String refreshToken,
@@ -64,8 +65,20 @@ public interface AuthControllerDocs {
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class},
-            include = {"INVALID_TOKEN", "IN_BLACK_LIST", "EXPIRED_TOKEN", "MEMBER_NOT_FOUND"}
+            include = {"TOKEN_INVALID_ERROR", "TOKEN_BLACK_LIST_ERROR", "TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR"}
     )
     @Operation(summary = "로그아웃 API", description = "로그아웃 API 입니다.")
     public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request);
+
+
+    @ApiErrorCodeExamples(
+            value = {AuthErrorCode.class, MemberErrorCode.class, ApiErrorCode.class},
+            include = {"TOKEN_INVALID_ERROR", "TOKEN_BLACK_LIST_ERROR", "TOKEN_EXPIRED_ERROR", "MEMBER_NOT_FOUND_ERROR",
+            "EMPTY_FIELD_ERROR", "BAD_REQUEST_ERROR","TYPE_MISMATCH_ERROR", "INTERNAL_SERVER_ERROR",
+                    "KAKAO_REQUEST_ERROR"
+            }
+    )
+    @Operation(summary = "회원탈퇴 API", description = "회원 탈퇴 API 입니다.")
+    public ResponseEntity<ApiResponse<Void>> withdrawMember(@RequestBody AuthRequest.WithdrawDTO request,
+                                                            @RequestHeader("Authorization") String accessToken);
 }

--- a/src/main/java/oncog/cogroom/domain/auth/dto/request/AuthRequest.java
+++ b/src/main/java/oncog/cogroom/domain/auth/dto/request/AuthRequest.java
@@ -64,4 +64,15 @@ public class AuthRequest {
         @Email
         private String email;
     }
+
+    @Getter
+    @Builder
+    public static class WithdrawDTO {
+
+        @NotNull
+        private Long memberId;
+
+        @NotBlank
+        private Provider provider;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/AuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package oncog.cogroom.domain.auth.service;
 
 
 
+import lombok.With;
 import oncog.cogroom.domain.member.enums.Provider;
 
 import static oncog.cogroom.domain.auth.dto.request.AuthRequest.*;
@@ -13,5 +14,6 @@ public interface AuthService {
 
     SignupResultDTO signup(SignupDTO request);
 
+    void withdraw(WithdrawDTO request, String accessToken);
     Provider getProvider();
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/AuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/AuthService.java
@@ -2,7 +2,7 @@ package oncog.cogroom.domain.auth.service;
 
 
 
-import lombok.With;
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.enums.Provider;
 
 import static oncog.cogroom.domain.auth.dto.request.AuthRequest.*;
@@ -15,5 +15,7 @@ public interface AuthService {
     SignupResultDTO signup(SignupDTO request);
 
     void withdraw(WithdrawDTO request, String accessToken);
+
+    void unlink(Member member);
     Provider getProvider();
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/AuthServiceRouter.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/AuthServiceRouter.java
@@ -12,7 +12,7 @@ import static oncog.cogroom.domain.auth.dto.response.AuthResponse.LoginResultDTO
 import static oncog.cogroom.domain.auth.dto.response.AuthResponse.SignupResultDTO;
 
 /**
- * 해당 라우터를 통해 로그인의 진입점을 하나로 통일
+ * 해당 라우터를 통해 진입점을 하나로 통일
  */
 @Component
 public class AuthServiceRouter {
@@ -39,5 +39,11 @@ public class AuthServiceRouter {
         AuthService service = serviceMap.get(request.getProvider());
 
         return service.signup(request);
+    }
+
+    public void withdraw(AuthRequest.WithdrawDTO request, String accessToken) {
+        AuthService service = serviceMap.get(request.getProvider());
+
+        service.withdraw(request, accessToken);
     }
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/TokenService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/TokenService.java
@@ -1,0 +1,58 @@
+package oncog.cogroom.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import oncog.cogroom.domain.auth.exception.AuthErrorCode;
+import oncog.cogroom.domain.auth.exception.AuthException;
+import oncog.cogroom.global.security.jwt.JwtProvider;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenService {
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshExpiration;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JwtProvider jwtProvider;
+
+    // refresh Token이 redis에 존재하는지 검사
+    public void checkTokenInRedis(Long memberId) {
+        if (Boolean.FALSE.equals(redisTemplate.hasKey("RT:" + memberId)))
+            throw new AuthException(AuthErrorCode.TOKEN_INVALID_ERROR);
+    }
+
+    // RefreshToken 갱신
+    public void tokenRotation(String refreshToken, Long memberId) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set("RT:" + memberId, refreshToken, refreshExpiration, TimeUnit.DAYS);
+    }
+
+    // 로그아웃 & 회원 탈퇴시 액세스 토큰 블랙리스트, 리프레시 토큰 삭제 처리
+    public void expireToken(String accessToken, Long memberId) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+
+        // BlackList에 저장할 Key 생성
+        String key = "BL:" + DigestUtils.sha256Hex(accessToken);
+
+        // accessToken의 TTL 계산
+        Date expiration = jwtProvider.getExpiration(accessToken);
+        long remainTime = expiration.getTime() - System.currentTimeMillis();
+
+        // 블랙 리스트 설정
+        values.set(key, accessToken, remainTime, TimeUnit.MILLISECONDS);
+
+        // refreshToken 삭제
+        redisTemplate.delete("RT:" + memberId);
+    }
+
+}

--- a/src/main/java/oncog/cogroom/domain/auth/service/session/AuthSessionService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/session/AuthSessionService.java
@@ -4,8 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.auth.dto.response.AuthResponse;
-import oncog.cogroom.domain.auth.exception.AuthErrorCode;
-import oncog.cogroom.domain.auth.exception.AuthException;
+import oncog.cogroom.domain.auth.service.TokenService;
 import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.exception.MemberErrorCode;
 import oncog.cogroom.domain.member.exception.MemberException;
@@ -13,15 +12,8 @@ import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.common.service.BaseService;
 import oncog.cogroom.global.common.util.TokenUtil;
 import oncog.cogroom.global.security.jwt.JwtProvider;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional
@@ -29,13 +21,11 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class AuthSessionService extends BaseService {
 
-    @Value("${jwt.refresh-token-expiration}")
-    private long refreshExpiration;
 
     private final JwtProvider jwtProvider;
-    private final RedisTemplate<String, String> redisTemplate;
     private final TokenUtil tokenUtil;
     private final MemberRepository memberRepository;
+    private final TokenService tokenService;
 
     // 토큰 재발급 API
     public AuthResponse.ServiceTokenDTO reIssue(String refreshToken) {
@@ -45,7 +35,7 @@ public class AuthSessionService extends BaseService {
 
         Long memberId = jwtProvider.extractMemberId(refreshToken);
 
-        checkTokenInRedis(memberId);
+        tokenService.checkTokenInRedis(memberId);
 
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND_ERROR));
 
@@ -53,7 +43,7 @@ public class AuthSessionService extends BaseService {
         AuthResponse.ServiceTokenDTO tokenDTO = tokenUtil.createTokens(member);
 
         // 토큰 갱신
-        tokenRotation(tokenDTO.getRefreshToken(), memberId);
+        tokenService.tokenRotation(tokenDTO.getRefreshToken(), memberId);
 
         log.info("토큰 재발급 호출");
 
@@ -61,7 +51,6 @@ public class AuthSessionService extends BaseService {
     }
 
     public void logout(HttpServletRequest request) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
 
         // 사용자 ID 추출
         Long memberId = jwtProvider.extractMemberId();
@@ -69,31 +58,10 @@ public class AuthSessionService extends BaseService {
         // accessToken 추출
         String accessToken = jwtProvider.resolveToken(request);
 
-        // BlackList에 저장할 Key 생성
-        String key = "BL:" + DigestUtils.sha256Hex(accessToken);
-
-        // accessToken의 TTL 계산
-        Date expiration = jwtProvider.getExpiration(accessToken);
-        long remainTime = expiration.getTime() - System.currentTimeMillis();
-
-        log.info("remainTime : " + remainTime);
-
-        // 블랙 리스트 설정
-        values.set(key, accessToken, remainTime, TimeUnit.MILLISECONDS);
-
-        // refreshToken 삭제
-        redisTemplate.delete("RT:" + memberId);
+        tokenService.expireToken(accessToken,  memberId);
     }
 
-    // refresh Token이 redis에 존재하는지 검사
-    private void checkTokenInRedis(Long memberId) {
-        if(Boolean.FALSE.equals(redisTemplate.hasKey("RT:" + memberId))) throw new AuthException(AuthErrorCode.TOKEN_INVALID_ERROR);
-    }
 
-    // RefreshToken 갱신
-    private void tokenRotation(String refreshToken,Long memberId) {
-        ValueOperations<String, String> values = redisTemplate.opsForValue();
-        values.set("RT:" + memberId, refreshToken, refreshExpiration, TimeUnit.DAYS);
-    }
+
 
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
@@ -103,6 +103,7 @@ public abstract class AbstractAuthService implements AuthService {
         memberRepository.save(member);
     }
 
+
     public final void saveRefreshTokenToRedis(String refreshToken, Long memberId) {
         redisTemplate.opsForValue().set("RT:" + memberId, refreshToken, refreshExpiration, TimeUnit.DAYS);
     }
@@ -123,5 +124,4 @@ public abstract class AbstractAuthService implements AuthService {
 
     protected abstract SocialUserInfo requestUserInfo(String accessToken);
 
-    protected abstract void unlink(String providerId);
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
@@ -47,9 +47,8 @@ public class KakaoAuthService extends AbstractAuthService {
         try {
             HttpEntity<MultiValueMap<String, String>> request = getHttpEntityForToken(code);
 
-            ResponseEntity<SocialTokenResponse.KakaoTokenDTO> response = restTemplate.exchange(
+            ResponseEntity<SocialTokenResponse.KakaoTokenDTO> response = restTemplate.postForEntity(
                     "https://kauth.kakao.com/oauth/token",
-                    HttpMethod.POST,
                     request,
                     SocialTokenResponse.KakaoTokenDTO.class
             );
@@ -67,12 +66,11 @@ public class KakaoAuthService extends AbstractAuthService {
     @Override
     protected SocialUserInfo requestUserInfo(String accessToken) {
         try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(accessToken);
+            HttpEntity<Void> request = createBearerRequest(accessToken);
 
             KakaoUserInfoDTO responseDTO = restTemplate.postForEntity(
                     "https://kapi.kakao.com/v2/user/me",
-                    new HttpEntity<>(headers),
+                    request,
                     KakaoUserInfoDTO.class
             ).getBody();
 
@@ -86,9 +84,7 @@ public class KakaoAuthService extends AbstractAuthService {
 
     @Override
     public void unlink(Member member) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        headers.set("Authorization", "KakaoAK " + adminKey);
+        HttpHeaders headers = createAdminHeader();
 
         LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("target_id_type", "user_id");
@@ -119,4 +115,16 @@ public class KakaoAuthService extends AbstractAuthService {
         return new HttpEntity<>(params, headers);
     }
 
+    private HttpEntity<Void> createBearerRequest(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        return new HttpEntity<>(headers);
+    }
+
+    private HttpHeaders createAdminHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "KakaoAK " + adminKey);
+        return headers;
+    }
 }

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/KakaoAuthService.java
@@ -6,6 +6,7 @@ import oncog.cogroom.domain.auth.service.EmailService;
 import oncog.cogroom.domain.auth.service.TokenService;
 import oncog.cogroom.domain.auth.userInfo.KakaoUserInfo;
 import oncog.cogroom.domain.auth.userInfo.SocialUserInfo;
+import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.enums.Provider;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.common.util.TokenUtil;
@@ -84,20 +85,19 @@ public class KakaoAuthService extends AbstractAuthService {
     }
 
     @Override
-    protected void unlink(String providerId) {
+    public void unlink(Member member) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", "KakaoAK " + adminKey);
 
         LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("target_id_type", "user_id");
-        body.add("target_id", providerId);
+        body.add("target_id", member.getProviderId());
 
         HttpEntity<LinkedMultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
-        restTemplate.exchange(
+        restTemplate.postForEntity(
                 "https://kapi.kakao.com/v1/user/unlink",
-                HttpMethod.POST,
                 request,
                 String.class
         );

--- a/src/main/java/oncog/cogroom/domain/member/event/MembersWithdrawalEventListener.java
+++ b/src/main/java/oncog/cogroom/domain/member/event/MembersWithdrawalEventListener.java
@@ -1,6 +1,7 @@
 package oncog.cogroom.domain.member.event;
 
 import lombok.RequiredArgsConstructor;
+import oncog.cogroom.domain.auth.service.AuthService;
 import oncog.cogroom.domain.daily.entity.Answer;
 import oncog.cogroom.domain.daily.entity.AssignedQuestion;
 import oncog.cogroom.domain.daily.repository.AnswerRepository;
@@ -13,8 +14,7 @@ import oncog.cogroom.domain.streak.repository.StreakLogRepository;
 import oncog.cogroom.domain.streak.repository.StreakRepository;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+
 
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +28,7 @@ public class MembersWithdrawalEventListener {
     private final MemberService memberService;
     private final StreakRepository streakRepository;
     private final StreakLogRepository streakLogRepository;
+    private final AuthService authService;
 
     @EventListener()
     public void handleWithdrawnMembers(MembersWithDrawnEvent event) {
@@ -59,6 +60,8 @@ public class MembersWithdrawalEventListener {
                 streakLogRepository.saveAll(streakLogs);
             }
 
+            // 소셜 로그인까지 탈퇴
+            authService.unlink(member);
         }
     }
 

--- a/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
+++ b/src/main/java/oncog/cogroom/domain/member/service/MemberService.java
@@ -118,14 +118,13 @@ public class MemberService extends BaseService {
         List<Member> pendingMembers = memberRepository.findByStatus(MemberStatus.PENDING);
 
         if (!pendingMembers.isEmpty()) {
-            List<Member> withDrawMembers = pendingMembers.stream()
+            List<Member> withdrawnMembers = pendingMembers.stream()
                     .filter(member -> LocalDate.now().isAfter(member.getUpdatedAt().toLocalDate().plusDays(30)))
                     .collect(Collectors.toList());
 
-            eventPublisher.publishEvent(new MembersWithDrawnEvent(withDrawMembers));
+            eventPublisher.publishEvent(new MembersWithDrawnEvent(withdrawnMembers));
 
-            memberRepository.deleteAll(withDrawMembers);
-
+            memberRepository.deleteAll(withdrawnMembers);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,7 @@ spring:
 oauth:
   kakao:
     client-id: ${KAKAO_REST_API_KEY}
+    admin-key: ${KAKAO_ADMIN_KEY}
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: ${JWT_ACCESS_EXPIRATION}


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #138 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 회원 탈퇴 API 구현
- 회원 탈퇴 30일 이후 카카오 소셜 로그인도 탈퇴 되도록 스케줄러 수정
- 카카오 서비스 코드 리팩토링

## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
## 회원 탈퇴 api 실행
![image](https://github.com/user-attachments/assets/7f0ae98a-9734-4f0c-8e12-bbe3a49c93ac)

## 카카오 연동 해제되는 요청 로그
![image](https://github.com/user-attachments/assets/daac3e64-6756-468b-a481-eb33bd42aced)
