### PR TITLE
[REFACTOR] 로그인 API 수정(재로그인 로직)

### DIFF
--- a/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/AuthController.java
@@ -106,9 +106,9 @@ public class AuthController implements AuthControllerDocs {
         return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS));
     }
 
-    @PostMapping("/email/status")
-    public ResponseEntity<ApiResponse<Boolean>> checkEmailVerificationStatus(@RequestBody @Valid AuthRequest.EmailDTO request) {
-        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, emailService.verifiedEmail(request)));
+    @GetMapping("/email/status")
+    public ResponseEntity<ApiResponse<Boolean>> checkEmailVerificationStatus(@RequestParam String email) {
+        return ResponseEntity.ok(ApiResponse.of(ApiSuccessCode.SUCCESS, emailService.verifiedEmail(email)));
     }
 
 

--- a/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/oncog/cogroom/domain/auth/controller/docs/AuthControllerDocs.java
@@ -53,7 +53,7 @@ public interface AuthControllerDocs {
                                                          @RequestParam String verificationCode);
 
     @Operation(summary = "이메일 인증 여부 반환", description = "이메일의 인증이 완료되었는지 여부를 반환합니다.")
-    public ResponseEntity<ApiResponse<Boolean>> checkEmailVerificationStatus(@RequestBody @Valid AuthRequest.EmailDTO request);
+    public ResponseEntity<ApiResponse<Boolean>> checkEmailVerificationStatus(@RequestParam String email);
 
     @ApiErrorCodeExamples(
             value = {AuthErrorCode.class, MemberErrorCode.class},

--- a/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/EmailService.java
@@ -104,9 +104,8 @@ public class EmailService {
     }
 
     // 이메일의 인증 상태 반환
-    public boolean verifiedEmail(AuthRequest.EmailDTO request) {
-        String toEmail = request.getEmail();
-        return emailRepository.existsByEmailAndVerifyStatus(toEmail,true);
+    public boolean verifiedEmail(String email) {
+        return emailRepository.existsByEmailAndVerifyStatus(email,true);
     }
 
     // 이메일 인증 유무 검사

--- a/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
+++ b/src/main/java/oncog/cogroom/domain/auth/service/social/AbstractAuthService.java
@@ -1,19 +1,15 @@
 package oncog.cogroom.domain.auth.service.social;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import oncog.cogroom.domain.auth.dto.request.AuthRequest;
 import oncog.cogroom.domain.auth.dto.response.AuthResponse;
-import oncog.cogroom.domain.auth.entity.WithdrawReason;
-import oncog.cogroom.domain.auth.repository.WithdrawReasonRepository;
 import oncog.cogroom.domain.auth.service.AuthService;
 import oncog.cogroom.domain.auth.service.EmailService;
-import oncog.cogroom.domain.auth.service.TokenService;
 import oncog.cogroom.domain.auth.userInfo.SocialUserInfo;
 import oncog.cogroom.domain.member.entity.Member;
 import oncog.cogroom.domain.member.enums.MemberRole;
 import oncog.cogroom.domain.member.enums.MemberStatus;
-import oncog.cogroom.domain.member.exception.MemberErrorCode;
-import oncog.cogroom.domain.member.exception.MemberException;
 import oncog.cogroom.domain.member.repository.MemberRepository;
 import oncog.cogroom.global.common.util.TokenUtil;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,7 +43,12 @@ public abstract class AbstractAuthService implements AuthService {
             Member member = memberOpt.get();
 
             // 탈퇴 유예 기간에 재로그인 하는 경우 다시 계정 활성화
-            if(member.getStatus().equals(MemberStatus.PENDING)) member.updateMemberStatusToActive();
+            if(member.getStatus().equals(MemberStatus.PENDING)) {
+                member.updateMemberStatusToActive();
+
+                // ACTIVE로 변경된 사용자 상태 저장
+                memberRepository.save(member);
+            }
 
             AuthResponse.ServiceTokenDTO tokenDTO = tokenUtil.createTokens(member);
 

--- a/src/main/java/oncog/cogroom/domain/member/entity/Member.java
+++ b/src/main/java/oncog/cogroom/domain/member/entity/Member.java
@@ -67,7 +67,7 @@ public class Member extends BaseTimeEntity {
 
 
     public void updateMemberStatusToActive(){
-        this.status = MemberStatus.PENDING;
+        this.status = MemberStatus.ACTIVE;
     }
 
     public void updateMemberRole(MemberRole role) {

--- a/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
+++ b/src/main/java/oncog/cogroom/global/config/SecurityConfig.java
@@ -130,7 +130,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000", "https://api.cogroom.com", "https://preview.cogroom.com", "https://cogroom-preview/**", "https://staging.cogroom.com"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "https://api.cogroom.com", "https://preview.cogroom.com", "https://cogroom-preview/**", "https://staging.cogroom.com", "https://cogroom.com"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization")); // Authorization 헤더 노출되도록 설정

--- a/src/main/java/oncog/cogroom/global/config/SwaggerConfig.java
+++ b/src/main/java/oncog/cogroom/global/config/SwaggerConfig.java
@@ -40,8 +40,6 @@ public class SwaggerConfig {
                 .description("JWT 인증 토큰 사용 (Bearer {Token})");
 
         SecurityRequirement securityRequirement = new SecurityRequirement().addList("JWT TOKEN");
-        Server server = new Server();
-        server.setUrl("https://api.cogroom.com");
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("JWT TOKEN", securityScheme))
@@ -50,7 +48,11 @@ public class SwaggerConfig {
                         .title("Cogroom API")
                         .version("1.0")
                         .description("온코그니어 코그룸 API 명세서입니다."))
-                .servers(List.of(server));
+                .servers(List.of(
+                        new Server().url("https://api.cogroom.com").description("Production server"),
+                        new Server().url("https://dev-api.cogroom.com").description("Development server"),
+                        new Server().url("https://staging-api.cogroom.com").description("Staging server")
+                ));
     }
 
     // 커스텀 어노테이션 정보 가져오기


### PR DESCRIPTION
### 🚀 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] Feat : 새로운 기능 추가
- [ ] Fix : 버그 수정
- [ ] Docs : 문서 수정
- [ ] Style : 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [ ] Refactor : 코드 리펙토링

## 🌱 관련 이슈
- close #166 

## 📌 변경 사항
<!-- 이 PR로 인해 바뀌게 되는 것들을 목록으로 적어주세요. -->
- 재로그인 시 회원 상태가 PENDING -> ACTIVE로 수정 안되는 문제 해결

## 📝 참고사항
<!-- 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다. -->
```
2025-07-09T21:17:38.170+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.security.web.FilterChainProxy        : Securing POST /api/v1/auth/login
2025-07-09T21:17:38.186+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.security.web.FilterChainProxy        : Secured POST /api/v1/auth/login
2025-07-09T21:17:38.188+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.servlet.DispatcherServlet        : POST "/api/v1/auth/login", parameters={}
2025-07-09T21:17:38.191+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] s.w.s.m.m.a.RequestMappingHandlerMapping : Mapped to oncog.cogroom.domain.auth.controller.AuthController#login(LoginDTO, HttpServletResponse)
2025-07-09T21:17:38.192+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.j.s.OpenEntityManagerInViewInterceptor : Opening JPA EntityManager in OpenEntityManagerInViewInterceptor
2025-07-09T21:17:38.280+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] m.m.a.RequestResponseBodyMethodProcessor : Read "application/json;charset=UTF-8" to [oncog.cogroom.domain.auth.dto.request.AuthRequest$LoginDTO@36460a58]
2025-07-09T21:17:38.362+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : HTTP POST https://kauth.kakao.com/oauth/token
2025-07-09T21:17:38.374+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Accept=[application/json, application/yaml, application/*+json]
2025-07-09T21:17:38.375+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Writing [{grant_type=[authorization_code], client_id=[c9220fdd9d50b4848d056ace131b91c3], code=[LrjqZ7JeZvnTjDWK9yLqYxhc_npbLBLW85U3ZaYr2K9M9GgpZsbgLgAAAAQKFwFQAAABl-8ejnPmTYKY7N6ACw]}] as "application/x-www-form-urlencoded"
2025-07-09T21:17:38.558+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Response 200 OK
2025-07-09T21:17:38.560+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Reading to [oncog.cogroom.domain.auth.dto.response.SocialTokenResponse$KakaoTokenDTO]
2025-07-09T21:17:38.568+09:00  INFO 45100 --- [cogroom] [nio-8080-exec-4] o.c.d.a.service.social.KakaoAuthService  : 카카오 토큰 응답: oncog.cogroom.domain.auth.dto.response.SocialTokenResponse$KakaoTokenDTO@58d8ce4d
2025-07-09T21:17:38.568+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : HTTP POST https://kapi.kakao.com/v2/user/me
2025-07-09T21:17:38.588+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Accept=[application/json, application/yaml, application/*+json]
2025-07-09T21:17:38.705+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Response 200 OK
2025-07-09T21:17:38.705+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.web.client.RestTemplate              : Reading to [oncog.cogroom.domain.auth.dto.response.SocialUserInfo$KakaoUserInfoDTO]
Hibernate: 
    select
        m1_0.id,
        m1_0.created_at,
        m1_0.description,
        m1_0.email,
        m1_0.nickname,
        m1_0.phone_number,
        m1_0.profile_image_url,
        m1_0.provider,
        m1_0.provider_id,
        m1_0.role,
        m1_0.status,
        m1_0.updated_at 
    from
        member m1_0 
    where
        m1_0.provider=? 
        and m1_0.provider_id=?
2025-07-09T21:17:38.807+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.orm.jpa.JpaTransactionManager        : Found thread-bound EntityManager [SessionImpl(250122954<open>)] for JPA transaction
2025-07-09T21:17:38.808+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.orm.jpa.JpaTransactionManager        : Creating new transaction with name [org.springframework.data.jpa.repository.support.SimpleJpaRepository.save]: PROPAGATION_REQUIRED,ISOLATION_DEFAULT
2025-07-09T21:17:38.812+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.orm.jpa.JpaTransactionManager        : Exposing JPA transaction as JDBC [org.springframework.orm.jpa.vendor.HibernateJpaDialect$HibernateConnectionHandle@1aeb7e28]
2025-07-09T21:17:38.820+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.orm.jpa.JpaTransactionManager        : Initiating transaction commit
2025-07-09T21:17:38.820+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.orm.jpa.JpaTransactionManager        : Committing JPA transaction on EntityManager [SessionImpl(250122954<open>)]
2025-07-09T21:17:38.842+09:00 DEBUG 45100 --- [cogroom] [nio-8080-exec-4] o.s.d.auditing.AuditingHandlerSupport    : Touched oncog.cogroom.domain.member.entity.Member@38affdf6 - Last modification at 2025-07-09T21:17:38.834847500 by unknown
Hibernate: 
    update
        member 
    set
        description=?,
        email=?,
        nickname=?,
        phone_number=?,
        profile_image_url=?,
        provider=?,
        provider_id=?,
        role=?,
        status=?,
        updated_at=? 
    where
        id=?
```

로그인 호출 후 사용자 상태 변경되는 쿼리 확인